### PR TITLE
Fix OS detection for cross-platform protoc compatibility

### DIFF
--- a/run_server.ps1
+++ b/run_server.ps1
@@ -53,7 +53,7 @@ if ($null -eq $MvnCmd) {
     Write-Warning "mvn.cmd not found in PATH or common locations. Falling back to 'mvn'."
     $MvnExecutable = "mvn"
 } else {
-    $MvnExecutable = $MvnCmd.FullName
+    $MvnExecutable = "mvn.cmd"
 }
 
 $DATA_DIR = Join-Path $PSScriptRoot "data"

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -14,8 +14,7 @@
     <build.dist.dir>target_test</build.dist.dir>
     <generated.sources.dir>${build.dist.dir}/generated-sources/protobuf/java</generated.sources.dir>
     <protobuf.java.version>3.25.1</protobuf.java.version>
-    <os.detected.classifier>osx-x86_64</os.detected.classifier>
-  </properties>
+      </properties>
   <dependencies>
     <dependency>
       <groupId>io.javalin</groupId>


### PR DESCRIPTION
## Problem
The server script was hardcoded to use macOS protoc binary, causing failures on Windows and other platforms.

## Changes Made
- Removed hardcoded os.detected.classifier from server/pom.xml
- Fixed Maven execution in run_server.ps1 to use command names instead of full paths
- Now uses dynamic OS detection via os-maven-plugin

## Impact
- Server now works cross-platform (Windows, macOS, Linux)
- Automatically detects OS and downloads correct protoc binary
- Resolves platform compatibility errors