### PR TITLE
Improve kill script robustness and error handling

### DIFF
--- a/kill_client_server.ps1
+++ b/kill_client_server.ps1
@@ -2,16 +2,35 @@ Write-Host "Killing client and server processes..." -ForegroundColor Cyan
 
 # Ports: 4200 (Client), 7070 (Server), 27017 (Mongo)
 $Ports = @(4200, 7070, 27017)
+$KilledProcesses = @()
 
 foreach ($Port in $Ports) {
-    $conn = Get-NetTCPConnection -LocalPort $Port -ErrorAction SilentlyContinue
-    if ($conn) {
-        Write-Host "Killing process $($conn.OwningProcess) on port $Port..." -ForegroundColor Yellow
-        Stop-Process -Id $conn.OwningProcess -Force
+    $connections = Get-NetTCPConnection -LocalPort $Port -ErrorAction SilentlyContinue
+    foreach ($conn in $connections) {
+        $processId = $conn.OwningProcess
+        if ($processId -gt 0 -and $KilledProcesses -notcontains $processId) {
+            try {
+                Write-Host "Killing process $processId on port $Port..." -ForegroundColor Yellow
+                Stop-Process -Id $processId -Force -ErrorAction Stop
+                $KilledProcesses += $processId
+            } catch {
+                Write-Host "Could not kill process $processId on port $Port - $($_.Exception.Message)" -ForegroundColor Yellow
+            }
+        }
     }
 }
 
 # Also kill by name as fallback
-Get-Process -Name java, node, mongod -ErrorAction SilentlyContinue | Stop-Process -Force
+Get-Process -Name java, node, mongod -ErrorAction SilentlyContinue | ForEach-Object {
+    if ($_.Id -gt 0 -and $KilledProcesses -notcontains $_.Id) {
+        try {
+            Write-Host "Killing $($_.ProcessName) process $($_.Id)..." -ForegroundColor Yellow
+            Stop-Process -Id $_.Id -Force -ErrorAction Stop
+            $KilledProcesses += $_.Id
+        } catch {
+            Write-Host "Could not kill $($_.ProcessName) process $($_.Id) - $($_.Exception.Message)" -ForegroundColor Yellow
+        }
+    }
+}
 
-Write-Host "Done." -ForegroundColor Green
+Write-Host "Done. Killed $($KilledProcesses.Count) processes." -ForegroundColor Green


### PR DESCRIPTION
## Problem
The kill script had several issues:
- Tried to kill the same process multiple times
- Attempted to kill invalid process IDs (like PID 0)
- Crashed on duplicate connections
- Poor error handling and feedback

## Changes Made
- Added duplicate process detection to avoid killing same process twice
- Added validation for process IDs (> 0) before attempting to kill
- Improved error handling with try-catch blocks
- Better feedback with clear success/failure messages
- Enhanced handling of multiple connections on same port
- Added summary count of killed processes

## Impact
- Script now handles edge cases gracefully
- No more crashes on invalid process IDs
- Clear feedback about what was killed
- Robust against duplicate connections and already-killed processes
- Tested successfully against running server and MongoDB processes