### PR TITLE
feat: Add configurable workers setting to Playwright config

### DIFF
--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   timeout: 120000,
   /* Retry on CI only */
   retries: process.env["CI"] ? 2 : 0,
-  workers: process.env["CI"] ? 1 : "100%",
+  workers: parseInt(process.env["PWTEST_WORKERS"] || "") || (process.env["CI"] ? 1 : "100%"),
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ["html"],


### PR DESCRIPTION
Configurable workers via PWTEST_WORKERS environment variable
Sensible defaults: CI=1 worker, local="100%" of available cores
Backward compatibility: Still works with existing workflows

Needed to not let my machine grind to a halt during tests