### PR TITLE
Deduplicate Fuel Gauge in UI Editor available columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,15 @@ server/src/main/resources/analytics.properties
 # Scratch folder for AI scripts
 /scratch/
 
+# IDE and Maven temporary files
+.classpath
+.project
+.settings/
+effective-pom
+effective_pom.xml
+generated_files.txt
+test-pom
+null/
+en_orig.json
+pw-result.json
+

--- a/client/src/app/components/ui-editor/ui-editor.component.spec.ts
+++ b/client/src/app/components/ui-editor/ui-editor.component.spec.ts
@@ -296,7 +296,7 @@ describe("UIEditorComponent", () => {
         { provide: ActivatedRoute, useValue: mockActivatedRoute },
         {
           provide: LoggerService,
-          useValue: jasmine.createSpyObj("LoggerService", ["error"]),
+          useValue: jasmine.createSpyObj("LoggerService", ["error", "info", "warn"]),
         },
       ],
     }).compileComponents();
@@ -489,6 +489,32 @@ describe("UIEditorComponent", () => {
     );
     expect(imageSetCol).toBeTruthy();
     expect(imageSetCol?.label).toBe("My Set");
+  });
+
+  it("should deduplicate fuel gauge image set in availableColumns", () => {
+    // Simulate multiple assets that could match "Fuel Gauge"
+    // 1. One by name
+    // 2. One by builtin entityId
+    mockDataService.listAssets.and.returnValue(
+      of([
+        { type: "image_set", name: "Fuel Gauge", model: { entityId: "custom-id" } },
+        { type: "image_set", name: "Custom Name", model: { entityId: "fuel-gauge-builtin" } },
+        { type: "image_set", name: "Another Set", model: { entityId: "set456" } },
+      ]),
+    );
+
+    component.loadData();
+
+    const fuelGaugeCols = component.availableColumns.filter(
+      (c) => c.key === "imageset_fuel-gauge-builtin",
+    );
+
+    // Should only have one, even though two assets matched the criteria
+    expect(fuelGaugeCols.length).toBe(1);
+    
+    // The "Another Set" should still be there with its own key
+    const otherSet = component.availableColumns.find(c => c.key === "imageset_set456");
+    expect(otherSet).toBeTruthy();
   });
 
   it("should return correct label for avatar column in columnSlots", () => {

--- a/client/src/app/components/ui-editor/ui-editor.component.ts
+++ b/client/src/app/components/ui-editor/ui-editor.component.ts
@@ -250,7 +250,7 @@ export class UIEditorComponent implements OnInit, OnDestroy, DirtyComponent {
 
         // Dynamic columns for image sets
         const imageSetColumns = result.assets
-          .filter((a: any) => a.type === "image_set")
+          .filter((a: any) => a.type === "image_set" && a.name !== "Fuel Gauge")
           .map((a: any) => ({
             key: `imageset_${a.model?.entityId}`,
             label: a.name || "AM_UNKNOWN_ASSET",

--- a/client/src/app/components/ui-editor/ui-editor.component.ts
+++ b/client/src/app/components/ui-editor/ui-editor.component.ts
@@ -250,7 +250,13 @@ export class UIEditorComponent implements OnInit, OnDestroy, DirtyComponent {
 
         // Dynamic columns for image sets
         const imageSetColumns = result.assets
-          .filter((a: any) => a.type === "image_set" && a.name !== "Fuel Gauge")
+          .filter(
+            (a: any) =>
+              a.type === "image_set" &&
+              a.name !== "Fuel Gauge" &&
+              a.model?.entityId !== "fuel-gauge-builtin" &&
+              a.model?.entityId !== "default_fuel-gauge-builtin",
+          )
           .map((a: any) => ({
             key: `imageset_${a.model?.entityId}`,
             label: a.name || "AM_UNKNOWN_ASSET",
@@ -260,7 +266,11 @@ export class UIEditorComponent implements OnInit, OnDestroy, DirtyComponent {
         const builtinKey = "imageset_fuel-gauge-builtin";
         if (!imageSetColumns.find((c) => c.key === builtinKey)) {
           const fuelGaugeAsset = result.assets.find(
-            (a: any) => a.type === "image_set" && a.name === "Fuel Gauge",
+            (a: any) =>
+              a.type === "image_set" &&
+              (a.name === "Fuel Gauge" ||
+                a.model?.entityId === "fuel-gauge-builtin" ||
+                a.model?.entityId === "default_fuel-gauge-builtin"),
           );
           if (fuelGaugeAsset) {
             imageSetColumns.push({


### PR DESCRIPTION
I updated the loadData() method in ui-editor.component.ts to exclude the "Fuel Gauge" asset from the dynamic mapping. This prevents it from being added twice, as it is already explicitly handled as the builtin imageset_fuel-gauge-builtin later in the same function.