### PR TITLE
fix: resolve missing Fuel Gauge and broken custom image set labels in UI Editor

### DIFF
--- a/client/src/app/components/ui-editor/column-preview/column-preview.component.spec.ts
+++ b/client/src/app/components/ui-editor/column-preview/column-preview.component.spec.ts
@@ -1,0 +1,134 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { Pipe, PipeTransform } from "@angular/core";
+import { ColumnPreviewComponent } from "./column-preview.component";
+import { AnchorPoint } from "@app/components/raceday/column_definition";
+import { ColumnVisibility } from "@app/models/settings";
+
+@Pipe({ name: "translate", standalone: true })
+class MockTranslatePipe implements PipeTransform {
+  transform(value: string): string {
+    return value;
+  }
+}
+
+describe("ColumnPreviewComponent", () => {
+  let component: ColumnPreviewComponent;
+  let fixture: ComponentFixture<ColumnPreviewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        ColumnPreviewComponent,
+        MockTranslatePipe,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ColumnPreviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe("getLabel", () => {
+    it("should return empty string for undefined prop", () => {
+      expect(component.getLabel(undefined)).toBe("");
+    });
+
+    it("should return correct label for static known columns", () => {
+      expect(component.getLabel("lapCount")).toBe("RD_COL_LAP");
+      expect(component.getLabel("driver.name")).toBe("RD_COL_NAME");
+    });
+
+    it("should resolve imageset_fuel-gauge-builtin to RD_COL_FUEL_GAUGE", () => {
+      expect(component.getLabel("imageset_fuel-gauge-builtin")).toBe("RD_COL_FUEL_GAUGE");
+    });
+
+    it("should find custom imagesets in columnSlots", () => {
+      fixture.componentRef.setInput("columnSlots", [
+        { key: "imageset_my-set", label: "My Custom Set" }
+      ]);
+      fixture.detectChanges();
+      expect(component.getLabel("imageset_my-set")).toBe("My Custom Set");
+    });
+
+    it("should match custom imagesets with index suffixes in columnSlots", () => {
+      fixture.componentRef.setInput("columnSlots", [
+        { key: "imageset_my-set", label: "My Custom Set" }
+      ]);
+      fixture.detectChanges();
+      expect(component.getLabel("imageset_my-set_1")).toBe("My Custom Set");
+    });
+
+    it("should strip imageset_ prefix if not found in columnSlots", () => {
+      fixture.componentRef.setInput("columnSlots", []);
+      fixture.detectChanges();
+      expect(component.getLabel("imageset_unloaded-set")).toBe("unloaded-set");
+    });
+  });
+
+  describe("getColumnLabel", () => {
+    it("should return translated label of CenterCenter property if active", () => {
+      fixture.componentRef.setInput("columnLayouts", {
+        slot1: { [AnchorPoint.CenterCenter]: "lapCount" }
+      });
+      fixture.detectChanges();
+      expect(component.getColumnLabel("slot1")).toBe("RD_COL_LAP");
+    });
+
+    it("should fallback to slot label if CenterCenter is empty", () => {
+      fixture.componentRef.setInput("columnSlots", [
+        { key: "slot1", label: "Fallback Slot Label" }
+      ]);
+      fixture.componentRef.setInput("columnLayouts", {
+        slot1: { [AnchorPoint.TopLeft]: "lapCount" }
+      });
+      fixture.detectChanges();
+      expect(component.getColumnLabel("slot1")).toBe("Fallback Slot Label");
+    });
+  });
+
+  describe("getAnchorValue", () => {
+    it("should return anchor value if configured in layout", () => {
+      fixture.componentRef.setInput("columnLayouts", {
+        slot1: { [AnchorPoint.TopLeft]: "reactionTime" }
+      });
+      fixture.detectChanges();
+      expect(component.getAnchorValue("slot1", AnchorPoint.TopLeft)).toBe("reactionTime");
+    });
+
+    it("should default CenterCenter to slotKey if no layout exists at all", () => {
+      fixture.componentRef.setInput("columnLayouts", {});
+      fixture.detectChanges();
+      expect(component.getAnchorValue("slot1", AnchorPoint.CenterCenter)).toBe("slot1");
+    });
+
+    it("should return undefined for CenterCenter if layout exists but CenterCenter is not defined", () => {
+      fixture.componentRef.setInput("columnLayouts", {
+        slot1: { [AnchorPoint.TopLeft]: "reactionTime" }
+      });
+      fixture.detectChanges();
+      expect(component.getAnchorValue("slot1", AnchorPoint.CenterCenter)).toBeUndefined();
+    });
+  });
+
+  describe("isOptional", () => {
+    it("should return true if columnVisibility is not Always", () => {
+      fixture.componentRef.setInput("columnVisibility", {
+        slot1: ColumnVisibility.FuelRaceOnly
+      });
+      fixture.detectChanges();
+      expect(component.isOptional("slot1")).toBeTrue();
+    });
+
+    it("should return false if columnVisibility is Always", () => {
+      fixture.componentRef.setInput("columnVisibility", {
+        slot1: ColumnVisibility.Always
+      });
+      fixture.detectChanges();
+      expect(component.isOptional("slot1")).toBeFalse();
+    });
+  });
+});

--- a/client/src/app/components/ui-editor/column-preview/column-preview.component.ts
+++ b/client/src/app/components/ui-editor/column-preview/column-preview.component.ts
@@ -25,7 +25,7 @@ const PREVIEW_LABELS: { [key: string]: string } = {
   "participant.fuelLevel": "RD_COL_FUEL_LEVEL",
   fuelCapacity: "RD_COL_FUEL_CAPACITY",
   fuelPercentage: "RD_COL_FUEL_PERCENTAGE",
-  imageset: "RD_COL_FUEL_GAUGE",
+  "imageset_fuel-gauge-builtin": "RD_COL_FUEL_GAUGE",
   mph: "RD_COL_MPH",
   kph: "RD_COL_KPH",
   fph: "RD_COL_FPH",
@@ -68,19 +68,33 @@ export class ColumnPreviewComponent {
 
   getLabel(prop: string | undefined): string {
     if (!prop) return "";
-    const baseKey = prop.split("_")[0];
 
+    // If it's a known static column or built-in, use the label key
+    if (PREVIEW_LABELS[prop]) {
+      return PREVIEW_LABELS[prop];
+    }
+
+    const baseKey = prop.split("_")[0];
     // If it's a known static column, use the label key
     if (PREVIEW_LABELS[baseKey]) {
       return PREVIEW_LABELS[baseKey];
     }
 
     // If it's an image set, try to find it in column slots to get the name
-    // TODO(aufderheide): I'm not sure we want this or not.  As long as it's not showing the
-    // uuid prefix for the asset it might be okay.
     if (prop.startsWith("imageset_")) {
-      const slot = this.columnSlots().find((s) => s.key === prop);
+      if (prop === "imageset_fuel-gauge-builtin") {
+        return "RD_COL_FUEL_GAUGE";
+      }
+      const slot = this.columnSlots().find(
+        (s) =>
+          s.key === prop ||
+          s.key.startsWith(prop + "_") ||
+          prop.startsWith(s.key + "_"),
+      );
       if (slot) return slot.label;
+
+      // If we still didn't find the slot, strip the "imageset_" prefix to make it look nicer
+      return prop.replace("imageset_", "");
     }
 
     return prop;

--- a/client/src/app/components/ui-editor/reorder-dialog/reorder-dialog.component.spec.ts
+++ b/client/src/app/components/ui-editor/reorder-dialog/reorder-dialog.component.spec.ts
@@ -437,4 +437,42 @@ describe("ReorderDialogComponent", () => {
       expect(component.columnSlots.length).toBe(1);
     });
   });
+
+  describe("getLabel", () => {
+    it("should resolve imageset_fuel-gauge-builtin to RD_COL_FUEL_GAUGE", () => {
+      fixture.componentRef.setInput("data", mockData);
+      fixture.detectChanges();
+      expect(component.getLabel("imageset_fuel-gauge-builtin")).toBe("RD_COL_FUEL_GAUGE");
+    });
+
+    it("should resolve keys from availableValuesMap if they match directly", () => {
+      fixture.componentRef.setInput("data", {
+        ...mockData,
+        availableValues: [
+          { key: "imageset_custom-imageset", label: "Custom Imageset Label" }
+        ]
+      });
+      fixture.detectChanges();
+      expect(component.getLabel("imageset_custom-imageset")).toBe("Custom Imageset Label");
+    });
+
+    it("should strip imageset_ prefix if key is not found in availableValuesMap", () => {
+      fixture.componentRef.setInput("data", mockData);
+      fixture.detectChanges();
+      expect(component.getLabel("imageset_some-other-imageset")).toBe("some-other-imageset");
+    });
+
+    it("should format dynamic duplicate indices correctly", () => {
+      fixture.componentRef.setInput("data", {
+        ...mockData,
+        availableValues: [
+          { key: "segmentTime", label: "RD_COL_SEGMENT_TIME" }
+        ]
+      });
+      fixture.detectChanges();
+      // Since mockTranslationService returns the key itself
+      expect(component.getLabel("segmentTime_2")).toBe("RD_COL_SEGMENT_TIME 3");
+    });
+  });
 });
+

--- a/client/src/app/components/ui-editor/reorder-dialog/reorder-dialog.component.ts
+++ b/client/src/app/components/ui-editor/reorder-dialog/reorder-dialog.component.ts
@@ -468,6 +468,12 @@ export class ReorderDialogComponent implements OnInit, OnDestroy {
       return "RD_COL_FUEL_GAUGE";
     }
 
+    // Try finding direct match first (e.g. custom image sets)
+    const directVal = this.availableValuesMap.get(key);
+    if (directVal) {
+      return directVal.label;
+    }
+
     const baseKey = key.split("_")[0];
     const val = this.availableValuesMap.get(baseKey);
     let label = val ? val.label : key;
@@ -479,6 +485,12 @@ export class ReorderDialogComponent implements OnInit, OnDestroy {
         return `${this.translationService.translate(label)} ${index}`;
       }
     }
+
+    // If it's a custom imageset but we didn't find it in availableValuesMap (e.g. not loaded yet), strip the prefix
+    if (key.startsWith("imageset_")) {
+      return key.replace("imageset_", "");
+    }
+
     return label;
   }
 

--- a/client/src/app/components/ui-editor/ui-editor.component.ts
+++ b/client/src/app/components/ui-editor/ui-editor.component.ts
@@ -133,6 +133,7 @@ export class UIEditorComponent implements OnInit, OnDestroy, DirtyComponent {
     { key: "participant.fuelLevel", label: "RD_COL_FUEL_LEVEL" },
     { key: "fuelCapacity", label: "RD_COL_FUEL_CAPACITY" },
     { key: "fuelPercentage", label: "RD_COL_FUEL_PERCENTAGE" },
+    { key: "imageset_fuel-gauge-builtin", label: "RD_COL_FUEL_GAUGE" },
     { key: "mph", label: "RD_COL_MPH" },
     { key: "kph", label: "RD_COL_KPH" },
     { key: "fph", label: "RD_COL_FPH" },
@@ -306,24 +307,6 @@ export class UIEditorComponent implements OnInit, OnDestroy, DirtyComponent {
             label: a.name || "AM_UNKNOWN_ASSET",
           }));
 
-        // Robustness: ensure imageset_fuel-gauge-builtin is available if a "Fuel Gauge" set exists
-        const builtinKey = "imageset_fuel-gauge-builtin";
-        if (!imageSetColumns.find((c) => c.key === builtinKey)) {
-          const fuelGaugeAsset = result.assets.find(
-            (a: any) =>
-              a.type === "image_set" &&
-              (a.name === "Fuel Gauge" ||
-                a.model?.entityId === "fuel-gauge-builtin" ||
-                a.model?.entityId === "default_fuel-gauge-builtin"),
-          );
-          if (fuelGaugeAsset) {
-            imageSetColumns.push({
-              key: builtinKey,
-              label: fuelGaugeAsset.name,
-            });
-          }
-        }
-
         // Reset availableColumns to base set + dynamic image sets
         this.availableColumns = [
           { key: "driver.name", label: "RD_COL_NAME" },
@@ -344,6 +327,7 @@ export class UIEditorComponent implements OnInit, OnDestroy, DirtyComponent {
           { key: "participant.fuelLevel", label: "RD_COL_FUEL_LEVEL" },
           { key: "fuelCapacity", label: "RD_COL_FUEL_CAPACITY" },
           { key: "fuelPercentage", label: "RD_COL_FUEL_PERCENTAGE" },
+          { key: "imageset_fuel-gauge-builtin", label: "RD_COL_FUEL_GAUGE" },
           { key: "mph", label: "RD_COL_MPH" },
           { key: "kph", label: "RD_COL_KPH" },
           { key: "fph", label: "RD_COL_FPH" },


### PR DESCRIPTION
# PR: fix(client): Resolve missing Fuel Gauge & broken custom image set labels in UI Editor

## 📝 Overview
This PR fixes the issue where the built-in **Fuel Gauge** column was missing from the "Available Columns" pool in the UI Editor. (https://github.com/daufderheide/racecoordinator_ai/issues/206). It also addresses two hidden issues with **custom user-added image sets** where their labels either fallback to raw UUID keys or incorrectly previewed as "FUEL GAUGE".



---

## 🛠️ Summary of Changes

### 1. Missing Built-in Fuel Gauge Column
* **Problem**: The UI Editor dynamically loaded the built-in Fuel Gauge column depending on dynamic API assets, making it fragile if assets failed or delayed loading.
* **Solution**: Permanently registered the Fuel Gauge column as a static available column.

### 2. Broken Custom Image Set Names in Reorder Dialog
* **Problem**: An over-aggressive string split on underscore (`_`) in the key parser caused custom image set lookups to fail and fallback to raw internal database IDs.
* **Solution**: Updated the label lookup to check for direct exact key matches first before splitting.

### 3. Custom Image Sets Mapped to "FUEL GAUGE" in Preview Grid
* **Problem**: A generic mapping rule intercepted all image sets starting with `imageset_` and displayed them under the "FUEL GAUGE" translation.
* **Solution**: Scoped the translation rule strictly to the built-in fuel gauge key (`imageset_fuel-gauge-builtin`) and enabled flexible fallback name formatting for other image sets.

---

## ✅ Verification
* Verified visually in the UI Editor (built-in Fuel Gauge is now fully restored in the pool).
* All unit tests passed: `TOTAL: 68 SUCCESS`.
