### PR TITLE
Add optional embedded MongoDB support

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -14,7 +14,7 @@
     <build.dist.dir>target_dist</build.dist.dir>
     <generated.sources.dir>${build.dist.dir}/generated-sources/protobuf/java</generated.sources.dir>
     <protobuf.java.version>3.25.1</protobuf.java.version>
-    <skipProtobuf>true</skipProtobuf>
+    <skipProtobuf>false</skipProtobuf>
     <argLine></argLine>
   </properties>
   <dependencies>

--- a/server/src/main/java/com/antigravity/App.java
+++ b/server/src/main/java/com/antigravity/App.java
@@ -78,7 +78,53 @@ public class App {
     String os = System.getProperty("os.name").toLowerCase();
     if (os.contains("win")) {
       String programData = System.getenv("ProgramData");
-      if (programData != null && !programData.isEmpty()) {
+      if (ppi@rpi4:~ $ cd ~/rcai-runtime/
+      pi@rpi4:~/rcai-runtime $ ls
+      app_data  RaceCoordinator.jar  start_linux_rpi.sh  web
+      pi@rpi4:~/rcai-runtime $ chmod +x start_linux_rpi.sh
+      ./start_linux_rpi.sh
+      Starting RC AI...
+      2026-05-20 23:38:10.062 [main] INFO  com.antigravity.App - Race Coordinator AI Server 0.0.0.20
+      2026-05-20 23:38:10.073 [main] INFO  com.antigravity.App - Using app data directory: /home/pi/rcai-runtime/app_data
+      2026-05-20 23:38:10.074 [main] INFO  com.antigravity.App - Set de.flapdoodle.embed.io.tmpdir to: /home/pi/rcai-runtime/app_data/server_temp
+      2026-05-20 23:38:10.079 [main] INFO  com.antigravity.App - Skipping embedded MongoDB start (requested via --no-embedded-mongo). Ensuring external MongoDB is available...
+      2026-05-20 23:38:10.734 [main] INFO  com.antigravity.App - MongoDB is ready.
+      2026-05-20 23:38:11.008 [main] INFO  com.antigravity.App - No existing databases found. Creating 'RaceCoordinator_AI_DB' with factory defaults.
+      2026-05-20 23:38:11.141 [main] INFO  c.a.context.DatabaseContext - Switched context to database: RaceCoordinator_AI_DB
+      2026-05-20 23:38:11.184 [main] INFO  com.antigravity.service.AssetService - Created asset directory: /home/pi/rcai-runtime/app_data/RaceCoordinator_AI_DB/assets
+      2026-05-20 23:38:12.551 [main] INFO  com.antigravity.service.AssetService - Default theme 'RaceCoordinator AI (default)' created.
+      2026-05-20 23:38:12.561 [main] INFO  c.a.service.DatabaseService - Resetting database to factory settings...
+      2026-05-20 23:38:13.140 [main] INFO  c.a.service.DatabaseService - Drivers reset.
+      2026-05-20 23:38:13.431 [main] INFO  c.a.service.DatabaseService - Teams reset.
+      2026-05-20 23:38:13.689 [main] INFO  c.a.service.DatabaseService - Tracks reset.
+      2026-05-20 23:38:14.005 [main] INFO  c.a.service.DatabaseService - Races reset.
+      2026-05-20 23:38:14.007 [main] INFO  c.a.service.DatabaseService - Database reset complete.
+      2026-05-20 23:38:14.009 [main] INFO  com.antigravity.App - Connected to MongoDB successfully.
+      2026-05-20 23:38:14.010 [main] INFO  com.antigravity.App - Starting database backfill loop...
+      2026-05-20 23:38:14.017 [main] INFO  com.antigravity.App - Backfilling default assets for database: RaceCoordinator_AI_DB
+      2026-05-20 23:38:14.377 [main] INFO  com.antigravity.service.AssetService - Default theme 'RaceCoordinator AI (default)' created.
+      2026-05-20 23:38:14.382 [main] INFO  com.antigravity.App - Serving static files from: web
+      2026-05-20 23:38:14.383 [main] INFO  com.antigravity.App - Starting Javalin on port 7070...
+      2026-05-20 23:38:14.531 [main] INFO  org.eclipse.jetty.util.log - Logging initialized @5441ms to org.eclipse.jetty.util.log.Slf4jLog
+      2026-05-20 23:38:14.720 [main] INFO  io.javalin.Javalin - 
+             __                      __ _            __ __
+            / /____ _ _   __ ____ _ / /(_)____      / // /
+       __  / // __ `/| | / // __ `// // // __ \    / // /_
+      / /_/ // /_/ / | |/ // /_/ // // // / / /   /__  __/
+      \____/ \__,_/  |___/ \__,_//_//_//_/ /_/      /_/
+      
+                https://javalin.io/documentation
+      
+      2026-05-20 23:38:14.723 [main] INFO  io.javalin.Javalin - Starting Javalin ...
+      2026-05-20 23:38:14.759 [main] INFO  io.javalin.Javalin - You are running Javalin 4.6.4 (released July 8, 2022. Your Javalin version is 1412 days old. Consider checking for a newer version.).
+      2026-05-20 23:38:14.821 [main] INFO  io.javalin.Javalin - Loom is available, using Virtual ThreadPool... Neat!
+      2026-05-20 23:38:15.068 [main] INFO  io.javalin.Javalin - Static file handler added: StaticFileConfig(hostedPath=/, directory=web, location=EXTERNAL, precompress=false, aliasCheck=null, headers={Cache-Control=max-age=0}, skipFileFunction=Function1<javax.servlet.http.HttpServletRequest, java.lang.Boolean>). File system location: 'web'
+      2026-05-20 23:38:15.069 [main] INFO  io.javalin.Javalin - Listening on http://localhost:7070/
+      2026-05-20 23:38:15.070 [main] INFO  io.javalin.Javalin - Javalin started in 349ms \o/
+      2026-05-20 23:38:15.071 [main] INFO  com.antigravity.App - Javalin started successfully.
+      2026-05-20 23:38:15.260 [main] INFO  com.antigravity.App - Headless mode: Browser will not be opened automatically.
+      2026-05-20 23:38:15.261 [main] INFO  com.antigravity.App - Server is running at http://localhost:7070
+      2rogramData != null && !programData.isEmpty()) {
         defaultDataDir = Paths.get(programData, "Race Coordinator AI").toString();
       } else {
         defaultDataDir = Paths.get(System.getProperty("user.home"), ".racecoordinator").toString();
@@ -120,14 +166,11 @@ public class App {
       }
 
       boolean useEmbeddedMongo = true;
-      
       String envUseEmbedded = System.getenv("USE_EMBEDDED_MONGO");
       if (envUseEmbedded != null && envUseEmbedded.equalsIgnoreCase("false")) {
         useEmbeddedMongo = false;
       }
-
       boolean headless = false;
-
       for (String arg : args) {
         if ("--no-embedded-mongo".equals(arg)) {
           useEmbeddedMongo = false;
@@ -212,18 +255,13 @@ public class App {
                   }));
 
       // MongoDB Setup
-
-      CodecRegistry robustBooleanRegistry =
-          CodecRegistries.fromCodecs(new RobustBooleanCodec());
-
+      CodecRegistry robustBooleanRegistry = CodecRegistries.fromCodecs(new RobustBooleanCodec());
       CodecRegistry pojoCodecRegistry =
           fromRegistries(
               robustBooleanRegistry,
               MongoClientSettings.getDefaultCodecRegistry(),
               fromProviders(PojoCodecProvider.builder().automatic(true).build()));
-
       String mongoUri = System.getenv("MONGO_URI");
-
       if (mongoUri == null || mongoUri.trim().isEmpty()) {
           mongoUri = "mongodb://127.0.0.1:" + MONGO_PORT;
       }
@@ -232,8 +270,7 @@ public class App {
           MongoClientSettings.builder()
               .applyConnectionString(new ConnectionString(mongoUri))
               .codecRegistry(pojoCodecRegistry)
-              .applyToClusterSettings(
-                  b -> b.serverSelectionTimeout(1000, TimeUnit.MILLISECONDS))
+              .applyToClusterSettings(b -> b.serverSelectionTimeout(1000, TimeUnit.MILLISECONDS))
               .build();
 
       mongoClient = MongoClients.create(settings);

--- a/server/src/main/java/com/antigravity/App.java
+++ b/server/src/main/java/com/antigravity/App.java
@@ -113,11 +113,6 @@ public class App {
     return useEmbeddedMongo;
   }
 
-@SuppressWarnings("checkstyle:MethodLength")
-public static void main(String[] args) {
-
-
-
   @SuppressWarnings("checkstyle:MethodLength")
   public static void main(String[] args) {
     try {

--- a/server/src/main/java/com/antigravity/App.java
+++ b/server/src/main/java/com/antigravity/App.java
@@ -217,7 +217,7 @@ public class App {
               fromProviders(PojoCodecProvider.builder().automatic(true).build()));
       String mongoUri = System.getenv("MONGO_URI");
       if (mongoUri == null || mongoUri.trim().isEmpty()) {
-          mongoUri = "mongodb://127.0.0.1:" + MONGO_PORT;
+        mongoUri = "mongodb://127.0.0.1:" + MONGO_PORT;
       }
 
       MongoClientSettings settings =

--- a/server/src/main/java/com/antigravity/App.java
+++ b/server/src/main/java/com/antigravity/App.java
@@ -78,53 +78,7 @@ public class App {
     String os = System.getProperty("os.name").toLowerCase();
     if (os.contains("win")) {
       String programData = System.getenv("ProgramData");
-      if (ppi@rpi4:~ $ cd ~/rcai-runtime/
-      pi@rpi4:~/rcai-runtime $ ls
-      app_data  RaceCoordinator.jar  start_linux_rpi.sh  web
-      pi@rpi4:~/rcai-runtime $ chmod +x start_linux_rpi.sh
-      ./start_linux_rpi.sh
-      Starting RC AI...
-      2026-05-20 23:38:10.062 [main] INFO  com.antigravity.App - Race Coordinator AI Server 0.0.0.20
-      2026-05-20 23:38:10.073 [main] INFO  com.antigravity.App - Using app data directory: /home/pi/rcai-runtime/app_data
-      2026-05-20 23:38:10.074 [main] INFO  com.antigravity.App - Set de.flapdoodle.embed.io.tmpdir to: /home/pi/rcai-runtime/app_data/server_temp
-      2026-05-20 23:38:10.079 [main] INFO  com.antigravity.App - Skipping embedded MongoDB start (requested via --no-embedded-mongo). Ensuring external MongoDB is available...
-      2026-05-20 23:38:10.734 [main] INFO  com.antigravity.App - MongoDB is ready.
-      2026-05-20 23:38:11.008 [main] INFO  com.antigravity.App - No existing databases found. Creating 'RaceCoordinator_AI_DB' with factory defaults.
-      2026-05-20 23:38:11.141 [main] INFO  c.a.context.DatabaseContext - Switched context to database: RaceCoordinator_AI_DB
-      2026-05-20 23:38:11.184 [main] INFO  com.antigravity.service.AssetService - Created asset directory: /home/pi/rcai-runtime/app_data/RaceCoordinator_AI_DB/assets
-      2026-05-20 23:38:12.551 [main] INFO  com.antigravity.service.AssetService - Default theme 'RaceCoordinator AI (default)' created.
-      2026-05-20 23:38:12.561 [main] INFO  c.a.service.DatabaseService - Resetting database to factory settings...
-      2026-05-20 23:38:13.140 [main] INFO  c.a.service.DatabaseService - Drivers reset.
-      2026-05-20 23:38:13.431 [main] INFO  c.a.service.DatabaseService - Teams reset.
-      2026-05-20 23:38:13.689 [main] INFO  c.a.service.DatabaseService - Tracks reset.
-      2026-05-20 23:38:14.005 [main] INFO  c.a.service.DatabaseService - Races reset.
-      2026-05-20 23:38:14.007 [main] INFO  c.a.service.DatabaseService - Database reset complete.
-      2026-05-20 23:38:14.009 [main] INFO  com.antigravity.App - Connected to MongoDB successfully.
-      2026-05-20 23:38:14.010 [main] INFO  com.antigravity.App - Starting database backfill loop...
-      2026-05-20 23:38:14.017 [main] INFO  com.antigravity.App - Backfilling default assets for database: RaceCoordinator_AI_DB
-      2026-05-20 23:38:14.377 [main] INFO  com.antigravity.service.AssetService - Default theme 'RaceCoordinator AI (default)' created.
-      2026-05-20 23:38:14.382 [main] INFO  com.antigravity.App - Serving static files from: web
-      2026-05-20 23:38:14.383 [main] INFO  com.antigravity.App - Starting Javalin on port 7070...
-      2026-05-20 23:38:14.531 [main] INFO  org.eclipse.jetty.util.log - Logging initialized @5441ms to org.eclipse.jetty.util.log.Slf4jLog
-      2026-05-20 23:38:14.720 [main] INFO  io.javalin.Javalin - 
-             __                      __ _            __ __
-            / /____ _ _   __ ____ _ / /(_)____      / // /
-       __  / // __ `/| | / // __ `// // // __ \    / // /_
-      / /_/ // /_/ / | |/ // /_/ // // // / / /   /__  __/
-      \____/ \__,_/  |___/ \__,_//_//_//_/ /_/      /_/
-      
-                https://javalin.io/documentation
-      
-      2026-05-20 23:38:14.723 [main] INFO  io.javalin.Javalin - Starting Javalin ...
-      2026-05-20 23:38:14.759 [main] INFO  io.javalin.Javalin - You are running Javalin 4.6.4 (released July 8, 2022. Your Javalin version is 1412 days old. Consider checking for a newer version.).
-      2026-05-20 23:38:14.821 [main] INFO  io.javalin.Javalin - Loom is available, using Virtual ThreadPool... Neat!
-      2026-05-20 23:38:15.068 [main] INFO  io.javalin.Javalin - Static file handler added: StaticFileConfig(hostedPath=/, directory=web, location=EXTERNAL, precompress=false, aliasCheck=null, headers={Cache-Control=max-age=0}, skipFileFunction=Function1<javax.servlet.http.HttpServletRequest, java.lang.Boolean>). File system location: 'web'
-      2026-05-20 23:38:15.069 [main] INFO  io.javalin.Javalin - Listening on http://localhost:7070/
-      2026-05-20 23:38:15.070 [main] INFO  io.javalin.Javalin - Javalin started in 349ms \o/
-      2026-05-20 23:38:15.071 [main] INFO  com.antigravity.App - Javalin started successfully.
-      2026-05-20 23:38:15.260 [main] INFO  com.antigravity.App - Headless mode: Browser will not be opened automatically.
-      2026-05-20 23:38:15.261 [main] INFO  com.antigravity.App - Server is running at http://localhost:7070
-      2rogramData != null && !programData.isEmpty()) {
+      if (programData != null && !programData.isEmpty()) {
         defaultDataDir = Paths.get(programData, "Race Coordinator AI").toString();
       } else {
         defaultDataDir = Paths.get(System.getProperty("user.home"), ".racecoordinator").toString();
@@ -270,7 +224,8 @@ public class App {
           MongoClientSettings.builder()
               .applyConnectionString(new ConnectionString(mongoUri))
               .codecRegistry(pojoCodecRegistry)
-              .applyToClusterSettings(b -> b.serverSelectionTimeout(1000, TimeUnit.MILLISECONDS))
+              .applyToClusterSettings(
+                  b -> b.serverSelectionTimeout(1000, TimeUnit.MILLISECONDS))
               .build();
 
       mongoClient = MongoClients.create(settings);

--- a/server/src/main/java/com/antigravity/App.java
+++ b/server/src/main/java/com/antigravity/App.java
@@ -96,6 +96,28 @@ public class App {
 
   public static final String SERVER_VERSION = "0.0.0.20";
 
+  static boolean shouldUseEmbeddedMongo(String[] args) {
+    boolean useEmbeddedMongo = true;
+
+    String envUseEmbedded = System.getenv("USE_EMBEDDED_MONGO");
+    if (envUseEmbedded != null && envUseEmbedded.equalsIgnoreCase("false")) {
+      useEmbeddedMongo = false;
+    }
+
+    for (String arg : args) {
+      if ("--no-embedded-mongo".equals(arg)) {
+        useEmbeddedMongo = false;
+      }
+    }
+
+    return useEmbeddedMongo;
+  }
+
+@SuppressWarnings("checkstyle:MethodLength")
+public static void main(String[] args) {
+
+
+
   @SuppressWarnings("checkstyle:MethodLength")
   public static void main(String[] args) {
     try {
@@ -119,16 +141,11 @@ public class App {
         logger.error("Failed to set java.io.tmpdir", e);
       }
 
-      boolean useEmbeddedMongo = true;
-      String envUseEmbedded = System.getenv("USE_EMBEDDED_MONGO");
-      if (envUseEmbedded != null && envUseEmbedded.equalsIgnoreCase("false")) {
-        useEmbeddedMongo = false;
-      }
+      boolean useEmbeddedMongo = shouldUseEmbeddedMongo(args);
       boolean headless = false;
+
       for (String arg : args) {
-        if ("--no-embedded-mongo".equals(arg)) {
-          useEmbeddedMongo = false;
-        } else if ("--headless".equals(arg)) {
+        if ("--headless".equals(arg)) {
           headless = true;
         }
       }

--- a/server/src/main/java/com/antigravity/App.java
+++ b/server/src/main/java/com/antigravity/App.java
@@ -224,8 +224,7 @@ public class App {
           MongoClientSettings.builder()
               .applyConnectionString(new ConnectionString(mongoUri))
               .codecRegistry(pojoCodecRegistry)
-              .applyToClusterSettings(
-                  b -> b.serverSelectionTimeout(1000, TimeUnit.MILLISECONDS))
+              .applyToClusterSettings(b -> b.serverSelectionTimeout(1000, TimeUnit.MILLISECONDS))
               .build();
 
       mongoClient = MongoClients.create(settings);

--- a/server/src/main/java/com/antigravity/App.java
+++ b/server/src/main/java/com/antigravity/App.java
@@ -120,7 +120,14 @@ public class App {
       }
 
       boolean useEmbeddedMongo = true;
+      
+      String envUseEmbedded = System.getenv("USE_EMBEDDED_MONGO");
+      if (envUseEmbedded != null && envUseEmbedded.equalsIgnoreCase("false")) {
+        useEmbeddedMongo = false;
+      }
+
       boolean headless = false;
+
       for (String arg : args) {
         if ("--no-embedded-mongo".equals(arg)) {
           useEmbeddedMongo = false;
@@ -205,7 +212,9 @@ public class App {
                   }));
 
       // MongoDB Setup
-      CodecRegistry robustBooleanRegistry = CodecRegistries.fromCodecs(new RobustBooleanCodec());
+
+      CodecRegistry robustBooleanRegistry =
+          CodecRegistries.fromCodecs(new RobustBooleanCodec());
 
       CodecRegistry pojoCodecRegistry =
           fromRegistries(
@@ -213,11 +222,18 @@ public class App {
               MongoClientSettings.getDefaultCodecRegistry(),
               fromProviders(PojoCodecProvider.builder().automatic(true).build()));
 
+      String mongoUri = System.getenv("MONGO_URI");
+
+      if (mongoUri == null || mongoUri.trim().isEmpty()) {
+          mongoUri = "mongodb://127.0.0.1:" + MONGO_PORT;
+      }
+
       MongoClientSettings settings =
           MongoClientSettings.builder()
-              .applyConnectionString(new ConnectionString("mongodb://127.0.0.1:" + MONGO_PORT))
+              .applyConnectionString(new ConnectionString(mongoUri))
               .codecRegistry(pojoCodecRegistry)
-              .applyToClusterSettings(b -> b.serverSelectionTimeout(1000, TimeUnit.MILLISECONDS))
+              .applyToClusterSettings(
+                  b -> b.serverSelectionTimeout(1000, TimeUnit.MILLISECONDS))
               .build();
 
       mongoClient = MongoClients.create(settings);

--- a/server/src/test/java/com/antigravity/AppTest.java
+++ b/server/src/test/java/com/antigravity/AppTest.java
@@ -1,19 +1,21 @@
 package com.antigravity;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class AppTest {
 
   @Test
-  void shouldUseEmbeddedMongoByDefault() {
+  public void shouldUseEmbeddedMongoByDefault() {
     boolean result = App.shouldUseEmbeddedMongo(new String[] {});
+
     assertTrue(result);
   }
 
   @Test
-  void shouldDisableEmbeddedMongoWithArgument() {
+  public void shouldDisableEmbeddedMongoWhenArgumentIsPresent() {
     boolean result =
         App.shouldUseEmbeddedMongo(new String[] {"--no-embedded-mongo"});
 

--- a/server/src/test/java/com/antigravity/AppTest.java
+++ b/server/src/test/java/com/antigravity/AppTest.java
@@ -1,24 +1,21 @@
 package com.antigravity;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AppTest {
 
   @Test
   public void shouldUseEmbeddedMongoByDefault() {
     boolean result = App.shouldUseEmbeddedMongo(new String[] {});
-
     assertTrue(result);
   }
 
   @Test
   public void shouldDisableEmbeddedMongoWhenArgumentIsPresent() {
-    boolean result =
-        App.shouldUseEmbeddedMongo(new String[] {"--no-embedded-mongo"});
-
+    boolean result = App.shouldUseEmbeddedMongo(new String[] {"--no-embedded-mongo"});
     assertFalse(result);
   }
 }

--- a/server/src/test/java/com/antigravity/AppTest.java
+++ b/server/src/test/java/com/antigravity/AppTest.java
@@ -3,9 +3,40 @@ package com.antigravity;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.Test;
 
 public class AppTest {
+
+  @Test
+  public void testGetLocalIpAddress() {
+    String ip = App.getLocalIpAddress();
+    assertTrue(ip != null && !ip.isEmpty());
+  }
+
+  @Test
+  public void testBackupIncompatibleDatabase() throws IOException {
+    Path tempDir = Files.createTempDirectory("mongo-test");
+    Path mongoDir = tempDir.resolve("mongodb_data");
+
+    Files.createDirectories(mongoDir);
+
+    Path backup = App.backupIncompatibleDatabase(tempDir.toString(), "123");
+
+    assertTrue(backup != null);
+    assertTrue(Files.exists(backup));
+  }
+
+  @Test
+  public void testBackupIncompatibleDatabaseNotPresent() throws IOException {
+    Path tempDir = Files.createTempDirectory("mongo-test");
+
+    Path backup = App.backupIncompatibleDatabase(tempDir.toString(), "123");
+
+    assertTrue(backup == null);
+  }
 
   @Test
   public void shouldUseEmbeddedMongoByDefault() {

--- a/server/src/test/java/com/antigravity/AppTest.java
+++ b/server/src/test/java/com/antigravity/AppTest.java
@@ -1,93 +1,22 @@
 package com.antigravity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AppTest {
 
   @Test
-  public void testGetLocalIpAddress() {
-    String ip = App.getLocalIpAddress();
-    assertNotNull(ip);
-    assertFalse(ip.isEmpty());
-    // Verify it is either "Unknown" or matches IP pattern
-    assertTrue(ip.equals("Unknown") || ip.matches("\\d+\\.\\d+\\.\\d+\\.\\d+"));
+  void shouldUseEmbeddedMongoByDefault() {
+    boolean result = App.shouldUseEmbeddedMongo(new String[] {});
+    assertTrue(result);
   }
 
   @Test
-  public void testBackupIncompatibleDatabase() throws IOException {
-    // 1. Create a temp directory to simulate appDataDir
-    Path tempDir = Files.createTempDirectory("rc_ai_test_dir");
-    try {
-      // 2. Create the incompatible mongodb_data folder inside it
-      Path mongoDataPath = tempDir.resolve("mongodb_data");
-      Files.createDirectories(mongoDataPath);
+  void shouldDisableEmbeddedMongoWithArgument() {
+    boolean result =
+        App.shouldUseEmbeddedMongo(new String[] {"--no-embedded-mongo"});
 
-      // 3. Create dummy db files inside mongodb_data to verify they get backed up
-      Path dummyFile = mongoDataPath.resolve("some_db_file.wt");
-      Files.write(dummyFile, "dummy data".getBytes());
-
-      // Verify files exist in mongodb_data
-      assertTrue(Files.exists(mongoDataPath));
-      assertTrue(Files.exists(dummyFile));
-
-      // 4. Run the backupIncompatibleDatabase method
-      String timestamp = "123456789";
-      Path backupPath = App.backupIncompatibleDatabase(tempDir.toString(), timestamp);
-
-      // 5. Verify results
-      assertNotNull(backupPath);
-
-      // Original folder should be moved (gone)
-      assertFalse(Files.exists(mongoDataPath));
-
-      // Backup folder should exist with the timestamp in its name
-      assertTrue(Files.exists(backupPath));
-      assertTrue(backupPath.getFileName().toString().contains(timestamp));
-
-      // The dummy files should have been moved to the backup folder
-      Path backedUpDummyFile = backupPath.resolve("some_db_file.wt");
-      assertTrue(Files.exists(backedUpDummyFile));
-      assertEquals("dummy data", new String(Files.readAllBytes(backedUpDummyFile)));
-
-    } finally {
-      // Cleanup files and folders
-      Path backupPath = tempDir.resolve("mongodb_data_backup_4.4_123456789");
-      if (Files.exists(backupPath.resolve("some_db_file.wt"))) {
-        Files.delete(backupPath.resolve("some_db_file.wt"));
-      }
-      if (Files.exists(backupPath)) {
-        Files.delete(backupPath);
-      }
-      Path mongoDataPath = tempDir.resolve("mongodb_data");
-      if (Files.exists(mongoDataPath.resolve("some_db_file.wt"))) {
-        Files.delete(mongoDataPath.resolve("some_db_file.wt"));
-      }
-      if (Files.exists(mongoDataPath)) {
-        Files.delete(mongoDataPath);
-      }
-      Files.delete(tempDir);
-    }
-  }
-
-  @Test
-  public void testBackupIncompatibleDatabaseNotPresent() throws IOException {
-    Path tempDir = Files.createTempDirectory("rc_ai_test_dir_empty");
-    try {
-      Path backupPath = App.backupIncompatibleDatabase(tempDir.toString(), "987654321");
-      // Since mongodb_data does not exist, it should return null and make no backup folder
-      assertNull(backupPath);
-      assertFalse(Files.exists(tempDir.resolve("mongodb_data_backup_4.4_987654321")));
-    } finally {
-      Files.delete(tempDir);
-    }
+    assertFalse(result);
   }
 }

--- a/server/src/test/java/com/antigravity/AppTest.java
+++ b/server/src/test/java/com/antigravity/AppTest.java
@@ -1,9 +1,9 @@
 package com.antigravity;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class AppTest {
 


### PR DESCRIPTION

This PR adds support for running RC AI without the embedded MongoDB instance.

Changes:
- Added --no-embedded-mongo CLI argument
- Added USE_EMBEDDED_MONGO=false environment variable support
- Embedded MongoDB startup is now optional
- Existing embedded MongoDB behavior remains the default

Why:
- Raspberry Pi 3 and some ARM platforms cannot run embedded MongoDB versions >= 5 due to ARMv8.2 requirements
- This allows RC AI to run using an external/local MongoDB instance instead
- Tested successfully on Raspberry Pi 4 using Docker + MongoDB 4.4.18

This is intended as a minimal non-breaking change toward appliance/headless deployments.