### PR TITLE
fix: prevent client protobuf regeneration to avoid compatibility issues

### DIFF
--- a/run_server.ps1
+++ b/run_server.ps1
@@ -7,9 +7,10 @@ $env:Path = "$env:JAVA_HOME\bin;" + $env:Path
 $SERVER_DIR = "$PSScriptRoot\server"
 
 # Run generate_protos.ps1 to handle protobuf generation (like generate_protos.sh on Unix)
+# Use --server-only to avoid regenerating client protobuf files which can cause compatibility issues
 Write-Host "Generating Protobuf files..." -ForegroundColor Cyan
 Set-Location $SERVER_DIR
-& powershell -ExecutionPolicy Bypass -File generate_protos.ps1
+& powershell -ExecutionPolicy Bypass -File generate_protos.ps1 --server-only
 
 Write-Host "Starting Server..." -ForegroundColor Green
 Set-Location $SERVER_DIR


### PR DESCRIPTION
Add --server-only flag to generate_protos.ps1 call in run_server.ps1 to prevent regenerating client protobuf files. This fixes the 'reader.tag is not a function' error that occurs when the server regenerates client protobuf files that are incompatible with protobufjs v7.5.5.