### PR TITLE
Fix NG0956 warning in team-manager by using trackByDriver function

### DIFF
--- a/client/src/app/components/team-manager/team-manager.component.html
+++ b/client/src/app/components/team-manager/team-manager.component.html
@@ -81,7 +81,10 @@
             class="team-drivers-list"
             style="margin-top: 15px; display: flex; flex-wrap: wrap; gap: 10px"
           >
-            @for (driver of getDriversForTeam(selectedTeam); track driver) {
+            @for (
+              driver of getDriversForTeam(selectedTeam);
+              track trackByDriver($index, driver)
+            ) {
               <div
                 class="driver-badge"
                 style="

--- a/client/src/app/components/team-manager/team-manager.component.ts
+++ b/client/src/app/components/team-manager/team-manager.component.ts
@@ -320,4 +320,8 @@ export class TeamManagerComponent implements OnInit, OnDestroy {
   trackByTeam(index: number, team: Team): string {
     return team.entity_id;
   }
+
+  trackByDriver(index: number, driver: Driver): string {
+    return driver.entity_id;
+  }
 }


### PR DESCRIPTION
## Fix NG0956 Warning in Team Manager

### Problem
The team manager component was showing an Angular NG0956 warning:
> "The configured tracking expression (track by identity) caused re-creation of the entire collection of size 3. This is an expensive operation requiring destruction and subsequent creation of DOM nodes, directives, components etc."

The `@for` loop at line 84 in [team-manager.component.html](cci:7://file:///z:/racecoordinator_ai_windsurf/racecoordinator_ai/client/src/app/components/team-manager/team-manager.component.html:0:0-0:0) used `track driver` (object identity), but [getDriversForTeam()](cci:1://file:///z:/racecoordinator_ai_windsurf/racecoordinator_ai/client/src/app/components/team-manager/team-manager.component.ts:202:2-207:3) returns a new array instance each time it's called. Angular couldn't efficiently track the driver items and was destroying/recreating all 3 DOM nodes on every change detection cycle.

### Solution
- Added [trackByDriver()](cci:1://file:///z:/racecoordinator_ai_windsurf/racecoordinator_ai/client/src/app/components/team-manager/team-manager.component.ts:323:2-325:3) function in [team-manager.component.ts](cci:7://file:///z:/racecoordinator_ai_windsurf/racecoordinator_ai/client/src/app/components/team-manager/team-manager.component.ts:0:0-0:0) that tracks drivers by their unique `entity_id` field
- Updated the template to use `track trackByDriver($index, driver)` instead of `track driver`

### Impact
Angular can now efficiently track driver items by their stable identifier, preventing unnecessary DOM destruction and recreation. This improves performance and eliminates the console warning.