### PR TITLE
Fix: driver station value scaling to match nickname scaling

### DIFF
--- a/client/src/app/components/driver-station/driver-station.component.css
+++ b/client/src/app/components/driver-station/driver-station.component.css
@@ -105,10 +105,10 @@
   display: block;
 }
 
-/* Nickname scaling - shrink to fit */
+/* Nickname scaling - wrap first, then shrink */
 .data-row .value.nickname-value {
   white-space: normal;
-  font-size: clamp(1.5rem, 15cqw, 3.6rem);
+  font-size: clamp(2.5rem, 25cqw, 3.6rem);
   max-width: 100%;
   display: block;
   display: -webkit-box;
@@ -119,12 +119,12 @@
   line-height: 1;
 }
 
-/* Other values - keep original size */
+/* Other values - scale to fit */
 .data-row .value.shrink-value,
 .rank-col .value.shrink-value,
 .lap-col .value.shrink-value {
   white-space: nowrap;
-  font-size: 3.6rem;
+  font-size: clamp(2.5rem, 25cqw, 3.6rem);
   max-width: 100%;
   display: block;
 }


### PR DESCRIPTION
## What
Fixed driver station value scaling to match nickname scaling behavior.

## Why
Only the nickname scaled properly on smaller screens; other values (rank, lap count, lap time, gap, best lap) remained fixed size, causing layout issues on mobile devices.

## How
- Updated CSS to apply responsive scaling using container query units (`cqw`) to all data values
- Changed from fixed `3.6rem` to `clamp(2.5rem, 25cqw, 3.6rem)` for consistent scaling
- Nickname wraps to 2 lines before shrinking, other values scale proportionally

## Testing
- Verified on mobile device
- Tested browser resize behavior
- Confirmed all values scale appropriately