### PR TITLE
Fix standings not resetting to seed order on heat reset

### DIFF
--- a/server/src/main/java/com/antigravity/race/OverallStandings.java
+++ b/server/src/main/java/com/antigravity/race/OverallStandings.java
@@ -300,7 +300,10 @@ public class OverallStandings {
 
     return Comparator.<RaceParticipant, Boolean>comparing(
             p -> p.getDriver() != null && p.getDriver().isEmpty())
-        .thenComparing(comparator.thenComparing(getTieBreakerComparator()).thenComparingInt(RaceParticipant::getSeed));
+        .thenComparing(
+            comparator
+                .thenComparing(getTieBreakerComparator())
+                .thenComparingInt(RaceParticipant::getSeed));
   }
 
   private Comparator<RaceParticipant> getTieBreakerComparator() {

--- a/server/src/main/java/com/antigravity/race/OverallStandings.java
+++ b/server/src/main/java/com/antigravity/race/OverallStandings.java
@@ -300,7 +300,7 @@ public class OverallStandings {
 
     return Comparator.<RaceParticipant, Boolean>comparing(
             p -> p.getDriver() != null && p.getDriver().isEmpty())
-        .thenComparing(comparator.thenComparing(getTieBreakerComparator()));
+        .thenComparing(comparator.thenComparing(getTieBreakerComparator()).thenComparingInt(RaceParticipant::getSeed));
   }
 
   private Comparator<RaceParticipant> getTieBreakerComparator() {

--- a/server/src/test/java/com/antigravity/race/OverallStandingsTest.java
+++ b/server/src/test/java/com/antigravity/race/OverallStandingsTest.java
@@ -184,6 +184,64 @@ public class OverallStandingsTest {
   }
 
   @Test
+  public void testSeedOrderTieBreaker() {
+    HeatScoring heatScoring =
+        new HeatScoring(
+            FinishMethod.Timed, 10, HeatRanking.LAP_COUNT, HeatRankingTiebreaker.FASTEST_LAP_TIME);
+    OverallScoring overallScoring =
+        new OverallScoring(0, OverallRanking.LAP_COUNT, OverallRankingTiebreaker.FASTEST_LAP_TIME);
+    OverallStandings os = new OverallStandings(heatScoring, overallScoring, new GroupOptions());
+
+    RaceParticipant p1 = createDriver("D1", "id1");
+    RaceParticipant p2 = createDriver("D2", "id2");
+    p1.setSeed(1);
+    p2.setSeed(2);
+
+    List<RaceParticipant> drivers = new ArrayList<>();
+    drivers.add(p1);
+    drivers.add(p2);
+
+    List<Heat> heats = new ArrayList<>();
+    heats.add(createHeat(1, p1, 10, 100.0, p2, 10, 100.0));
+
+    os.recalculate(drivers, heats);
+
+    assertEquals(1, p1.getRank());
+    assertEquals(2, p2.getRank());
+    assertEquals(p1, drivers.get(0));
+    assertEquals(p2, drivers.get(1));
+  }
+
+  @Test
+  public void testOverallRankingSeedOrderTieBreaker() {
+    HeatScoring heatScoring =
+        new HeatScoring(
+            FinishMethod.Timed, 10, HeatRanking.LAP_COUNT, HeatRankingTiebreaker.FASTEST_LAP_TIME);
+    OverallScoring overallScoring =
+        new OverallScoring(0, OverallRanking.TOTAL_TIME, OverallRankingTiebreaker.FASTEST_LAP_TIME);
+    OverallStandings os = new OverallStandings(heatScoring, overallScoring, new GroupOptions());
+
+    RaceParticipant p1 = createDriver("D1", "id1");
+    RaceParticipant p2 = createDriver("D2", "id2");
+    p1.setSeed(1);
+    p2.setSeed(2);
+
+    List<RaceParticipant> drivers = new ArrayList<>();
+    drivers.add(p1);
+    drivers.add(p2);
+
+    List<Heat> heats = new ArrayList<>();
+    heats.add(createHeat(1, p1, 10, 100.0, p2, 10, 100.0));
+
+    os.recalculate(drivers, heats);
+
+    assertEquals(1, p1.getRank());
+    assertEquals(2, p2.getRank());
+    assertEquals(p1, drivers.get(0));
+    assertEquals(p2, drivers.get(1));
+  }
+
+  @Test
   public void testAverageLapRanking() {
     HeatScoring heatScoring =
         new HeatScoring(


### PR DESCRIPTION
### Fix Standings Not Resetting to Seed Order on Heat Reset

Fixes https://github.com/daufderheide/racecoordinator_ai/issues/267 and https://github.com/daufderheide/racecoordinator_ai/issues/268


**Problem:** 
When a heat is reset, all driver stats are zeroed out resulting in a tie. Because Java's sort is stable, drivers kept their previous out-of-order rankings instead of reverting to their initial seed order.

**Solution:**
Added `.thenComparingInt(RaceParticipant::getSeed)` as the final fallback tiebreaker in `OverallStandings.java`. Now, when metrics are tied (like on a heat reset), drivers correctly fall back to their original seed order.

**Testing:**
- Verified that heat resets properly revert the driver rankings back to their starting seed order.




