### PR TITLE
Race Day screen layout improvements

### DIFF
--- a/client/src/app/components/raceday/default-raceday.component.css
+++ b/client/src/app/components/raceday/default-raceday.component.css
@@ -175,8 +175,8 @@
 /* Top Info Bar */
 .top-info-bar {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  height: 42px;
+  grid-template-columns: 1fr auto 1fr;
+  height: 52px; /* reduced header height */
   background: transparent;
   width: 100%;
   box-sizing: border-box;
@@ -185,14 +185,29 @@
 
 .info-section {
   display: flex;
-  align-items: center;
+  flex-direction: row; /* keep label and value on one line */
+  align-items: baseline;
   justify-content: center;
   height: 100%;
   border-right: 1px solid rgba(0,0,0,0.15);
+  gap: 8px;
 }
 
 .info-section:last-child {
   border-right: none;
+}
+
+/* Header alignment: left race, center heat, right track */
+.top-info-bar > .info-section:first-child {
+  justify-content: flex-start;
+  padding-left: 16px;
+}
+.top-info-bar > .info-section:nth-child(2) {
+  justify-content: center;
+}
+.top-info-bar > .info-section:last-child {
+  justify-content: flex-end;
+  padding-right: 16px;
 }
 
 .label-text {
@@ -206,19 +221,35 @@
 }
 
 .value-text {
-  font-size: 18px;
-  font-weight: 700;
-  color: #f8fafc;
-  text-shadow: 0 0 8px rgba(255, 255, 255, 0.2);
+  font-size: 36px; /* match heat header */
+  font-weight: 900;
+  color: #ffffff;
+  text-shadow: 0 0 12px rgba(255, 255, 255, 0.35);
+  letter-spacing: 0.5px;
   font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
 }
 
+/* Larger heat header (center of top info bar) */
+.heat-text {
+  font-size: 36px;
+  font-weight: 900;
+  color: #ffffff;
+  text-shadow: 0 0 12px rgba(255, 255, 255, 0.35);
+  letter-spacing: 0.5px;
+}
+
+/* Spacing for Group label + colon */
+.group-label {
+  margin-right: 8px;
+  font-weight: 800;
+}
+
 .track-text {
-  font-size: 16px;
-  font-weight: 700;
-  color: #f8fafc;
+  font-size: 36px; /* match heat header */
+  font-weight: 900;
+  color: #ffffff;
+  text-shadow: 0 0 12px rgba(255, 255, 255, 0.35);
   font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
-  text-shadow: 0 0 8px rgba(255, 255, 255, 0.2);
 }
 
 /* Middle Panels */
@@ -342,49 +373,98 @@
   overflow: hidden;
 }
 
+.timer-panel-auto {
+  background: linear-gradient(135deg, rgba(255, 170, 0, 0.15), rgba(255, 170, 0, 0.35));
+  border-color: #ffaa00;
+  box-shadow: inset 0 0 14px rgba(255, 170, 0, 0.4);
+}
+
+.timer-panel-warmup {
+  background: linear-gradient(135deg, rgba(0, 255, 255, 0.15), rgba(0, 255, 255, 0.35));
+  border-color: #00ffff;
+  box-shadow: inset 0 0 14px rgba(0, 255, 255, 0.35);
+}
+
 .timer-wrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   width: 100%;
+  height: 100%;
+  padding: 8px 0;
+}
+
+.timer-main {
+  position: relative; /* container for absolutely positioned children */
+  display: block;
+  width: 100%;
+  flex: 1;
 }
 
 .timer-text {
-  font-family: 'Courier New', Courier, monospace;
-  font-size: 100px; /* Scaled down slightly to fit labels */
+  font-family: 'Tahoma', sans-serif;
+  font-size: 140px; /* Bigger timer font */
   font-weight: bold;
   color: #32cd32; /* LimeGreen */
-  text-shadow: 0 0 24px rgba(50, 205, 50, 0.5);
+  text-shadow: 0 0 28px rgba(50, 205, 50, 0.6);
   line-height: 1;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.heat-group-info {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.heat-main,
+.group-info {
+  font-size: 18px; /* reduced header size */
+  font-weight: 700;
+  color: #f8fafc;
+  text-shadow: 0 0 6px rgba(255, 255, 255, 0.12);
+}
+
+.group-info {
+  margin: 0;
 }
 
 .timer-status-labels {
   display: flex;
-  flex-direction: column;
+  flex-direction: row; /* place status and warmup on one line */
   align-items: center;
+  gap: 12px;
   margin-top: 4px;
 }
 
 .status-label {
-  font-family: 'Orbitron', sans-serif;
-  font-size: 16px;
-  font-weight: 700;
+  font-family: 'Tahoma', sans-serif;
+  font-size: 20px; /* match warmup size */
+  font-weight: 800; /* match warmup weight */
   color: #ffaa00; /* Gold */
   text-transform: uppercase;
-  letter-spacing: 2px;
-  text-shadow: 0 0 8px rgba(255, 170, 0, 0.5);
+  letter-spacing: 3px;
+  text-shadow: 0 0 12px rgba(255, 170, 0, 0.5);
 }
 
 .warmup-label {
-  font-family: 'Orbitron', sans-serif;
+  font-family: 'Tahoma', sans-serif;
   font-size: 20px;
   font-weight: 800;
   color: #00ffff; /* Neon Cyan */
   text-transform: uppercase;
   letter-spacing: 3px;
   text-shadow: 0 0 12px rgba(0, 255, 255, 0.6);
-  margin-top: 2px;
   animation: pulse-glow 1.5s infinite ease-in-out;
 }
 

--- a/client/src/app/components/raceday/default-raceday.component.html
+++ b/client/src/app/components/raceday/default-raceday.component.html
@@ -318,10 +318,10 @@
             <span class="value-text">{{ race.name }}</span>
           </div>
           <div class="info-section">
-            <span class="value-text">
+            <span class="value-text heat-text">
               Heat {{ heat.heatNumber }} of {{ totalHeats }}
               @if (race.group_options && race.group_options.enabled) {
-                - {{ "RE_GROUPS_LABEL" | translate }}: {{ heat.group + 1 }}
+                - <span class="group-label">{{ "RE_GROUPS_LABEL" | translate }}</span>{{ heat.group + 1 }}
               }
             </span>
           </div>
@@ -359,9 +359,15 @@
           <img [src]="getCurrentFlagUrl()" class="flag-image" alt="Race Flag" />
         </div>
         <!-- Timer Panel -->
-        <div class="panel-card timer-panel">
+        <div
+          class="panel-card timer-panel"
+          [class.timer-panel-warmup]="isWarmup"
+          [class.timer-panel-auto]="autoStatusLabel && !showCountdownOverlay"
+        >
           <div class="timer-wrapper">
-            <div class="timer-text">{{ formattedTime }}</div>
+            <div class="timer-main">
+              <div class="timer-text">{{ formattedTime }}</div>
+            </div>
             <div class="timer-status-labels">
               @if (autoStatusLabel && !showCountdownOverlay) {
                 <div class="status-label">

--- a/client/src/app/components/raceday/default-raceday.component.ts
+++ b/client/src/app/components/raceday/default-raceday.component.ts
@@ -216,6 +216,33 @@ export class DefaultRacedayComponent
     return "";
   }
 
+  protected get timerColor(): string {
+    if (this.showCountdownOverlay) {
+      return "#00ff00"; // Green
+    }
+    if (this.isWarmup) {
+      return "#00ffff"; // Cyan
+    }
+    if (this.autoStartRemaining > 0 || this.autoAdvanceRemaining > 0) {
+      return "#ffaa00"; // Gold
+    }
+    return "#32cd32"; // LimeGreen
+  }
+
+  protected get timerTextShadow(): string {
+    const color = this.timerColor;
+    if (color === "#00ff00") {
+      return "0 0 28px rgba(0, 255, 0, 0.6)"; // Green
+    }
+    if (color === "#00ffff") {
+      return "0 0 28px rgba(0, 255, 255, 0.6)"; // Cyan
+    }
+    if (color === "#ffaa00") {
+      return "0 0 28px rgba(255, 170, 0, 0.6)"; // Gold
+    }
+    return "0 0 28px rgba(50, 205, 50, 0.6)"; // LimeGreen
+  }
+
   protected get formattedTime(): string {
     const s = this.raceState;
     if (
@@ -589,7 +616,9 @@ export class DefaultRacedayComponent
           this.updateCountdownLamps(this.autoStartRemaining);
         }
 
-        if (time > this.previousTime) {
+        if (this.autoStartRemaining > 0 || this.autoAdvanceRemaining > 0) {
+          this.timeFormat = "1.0-0";
+        } else if (time > this.previousTime) {
           this.timeFormat = "1.0-0";
         } else if (time < this.previousTime) {
           if (time < 10) {


### PR DESCRIPTION
- Branding panel text top-aligned (flex-start)
- QR code increased to 100x100px
- Timer hidden during countdown overlay (start lights)
- Timer labels: status above timer, warmup below
- Dynamic timer colors: green during countdown, cyan for warmup, gold for auto timers
- Timer font: 140px, status/warmup labels: 48px
- Integer time format for auto start/advance timers