### PR TITLE
Refresh client dependencies when manifests change

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ RaceCoordinator 2.0 built with google antigravity
 
 #### First Time Setup
 The `run_server_headless.sh` script handles dependency downloading (including `protoc`) automatically.
-The `run_client.sh` script handles `npm install` automatically if `node_modules` is missing.
+The `run_client.sh` script handles `npm install` automatically if `node_modules` is missing or the client dependency manifest changed.
 
 - Check permissions: `chmod +x run_server_headless.sh run_client.sh`
 - Run Server: `./run_server_headless.sh`
@@ -19,7 +19,7 @@ The `run_client.sh` script handles `npm install` automatically if `node_modules`
 
 #### First Time Setup
 The `run_server_headless.ps1` script handles dependency downloading (including `protoc`) automatically.
-The `run_client.ps1` script handles `npm install` automatically if `node_modules` is missing.
+The `run_client.ps1` script handles `npm install` automatically if `node_modules` is missing or the client dependency manifest changed.
 
 - Run Server: `.\run_server_headless.ps1`
 - Run Client: `.\run_client.ps1` (will take a moment to install dependencies first time)

--- a/run_client.ps1
+++ b/run_client.ps1
@@ -8,9 +8,14 @@ if (Test-Path "$NodePath\npm.cmd") {
     $env:Path = "$NodePath;" + $env:Path
 }
 
-if (-not (Test-Path "node_modules")) {
-    Write-Host "First time setup: Installing dependencies..." -ForegroundColor Yellow
+$DependenciesMissing = -not (Test-Path "node_modules")
+$PackageJsonChanged = (Test-Path "node_modules") -and ((Get-Item "package.json").LastWriteTime -gt (Get-Item "node_modules").LastWriteTime)
+$PackageLockChanged = (Test-Path "node_modules") -and ((Get-Item "package-lock.json").LastWriteTime -gt (Get-Item "node_modules").LastWriteTime)
+
+if ($DependenciesMissing -or $PackageJsonChanged -or $PackageLockChanged) {
+    Write-Host "Installing/updating dependencies..." -ForegroundColor Yellow
     npm install
+    (Get-Item "node_modules").LastWriteTime = Get-Date
 }
 
 Write-Host "Generating Protos..." -ForegroundColor Cyan

--- a/run_client.sh
+++ b/run_client.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 cd "$(dirname "$0")/client"
 
-if [ ! -d "node_modules" ]; then
-    echo "First time setup: Installing dependencies..."
+if [ ! -d "node_modules" ] || [ package.json -nt node_modules ] || [ package-lock.json -nt node_modules ]; then
+    echo "Installing/updating dependencies..."
     npm install
+    touch node_modules
 fi
 
 npm run proto:gen


### PR DESCRIPTION
## Summary
- rerun client `npm install` when `package.json` or `package-lock.json` is newer than `node_modules`
- apply the same dependency-refresh check to both `run_client.sh` and `run_client.ps1`
- update README setup wording to match the new behavior

## Why
This addresses #276 where an existing `node_modules` directory caused the client scripts to skip installing newly added dependencies such as `qrcode`.

## Verification
- `bash -n run_client.sh`
- `node -e "const p=require('./client/package.json'); const l=require('./client/package-lock.json'); if(!p.dependencies.qrcode || !l.packages['node_modules/qrcode']) process.exit(1); console.log('qrcode declared in package and lockfile')"`
- `npm --prefix client pkg get dependencies.qrcode 'devDependencies.@types/qrcode'`
- `git diff --check`

Note: I could not run a PowerShell parser locally because `pwsh` is not installed in my environment; the PowerShell change mirrors the same timestamp check used by the shell script.