### PR TITLE
Fix driver sorting in Team Editor available drivers list

### DIFF
--- a/client/src/app/components/team-editor/team-editor.component.ts
+++ b/client/src/app/components/team-editor/team-editor.component.ts
@@ -32,6 +32,7 @@ import { LoggerService } from "@app/services/logger.service";
 import { RaceConnectionService } from "@app/services/race-connection.service";
 import { SettingsService } from "@app/services/settings.service";
 import { TranslationService } from "@app/services/translation.service";
+import { naturalSortCompare } from "@app/utils/sorting.utils";
 
 @Component({
   standalone: true,
@@ -489,7 +490,9 @@ export class TeamEditorComponent implements OnInit, OnDestroy {
 
   get availableDrivers(): Driver[] {
     if (!this.allDrivers) return [];
-    return this.allDrivers.filter((d) => !this.isDriverInTeam(d));
+    return this.allDrivers
+      .filter((d) => !this.isDriverInTeam(d))
+      .sort((a, b) => naturalSortCompare(a.name, b.name));
   }
 
   isDriverInTeam(driver: Driver): boolean {


### PR DESCRIPTION
The "Available Drivers" list in the Team Editor was displaying drivers in the order they were returned from the backend, which resulted in incorrect ordering (e.g., Driver5 appearing after Driver8 instead of between Driver4 and Driver6).

Changes:

Added import for naturalSortCompare utility from @app/utils/sorting.utils
Updated the availableDrivers getter to sort filtered drivers by name using natural sort comparison

This ensures drivers are displayed in proper alphanumeric order (Driver1, Driver2, Driver3, Driver4, Driver5, Driver6, Driver7, Driver8, etc.)
