### PR TITLE
Add non-fuel race specific breakpoints for larger nickname fonts

### DIFF
--- a/client/src/app/components/driver-station/driver-station.component.css
+++ b/client/src/app/components/driver-station/driver-station.component.css
@@ -149,6 +149,25 @@
   }
 }
 
+/* Non-fuel races have more space, so use same breakpoints but larger fonts */
+@media (max-width: 900px) {
+  .driver-station-container:not(.fuel-race) .driver-row .value.nickname-value {
+    font-size: 3.3rem;
+  }
+}
+
+@media (max-width: 650px) {
+  .driver-station-container:not(.fuel-race) .driver-row .value.nickname-value {
+    font-size: 3rem;
+  }
+}
+
+@media (max-width: 550px) {
+  .driver-station-container:not(.fuel-race) .driver-row .value.nickname-value {
+    font-size: 2.5rem;
+  }
+}
+
 /* Other values - scale to fit */
 .data-row .value.shrink-value,
 .rank-col .value.shrink-value,


### PR DESCRIPTION
Continuation of https://github.com/daufderheide/racecoordinator_ai/pull/343

But now with a little bigger font for names in a non-fuel race, where there is no fuel column on the right

<img width="930" height="557" alt="image" src="https://github.com/user-attachments/assets/32a36e4a-ddff-4876-beb6-aaba5409ecc0" />
