### PR TITLE
Customize UI screen - color updates

### DIFF
--- a/client/src/app/components/raceday/components/raceday-absolute-widget/raceday-absolute-widget.component.css
+++ b/client/src/app/components/raceday/components/raceday-absolute-widget/raceday-absolute-widget.component.css
@@ -59,7 +59,7 @@
 
 .grab-icon {
   font-size: 14px;
-  color: #3b82f6;
+  color: #FFD700;
 }
 
 .widget-remove-btn {
@@ -80,7 +80,7 @@
 /* Resize Handles */
 .resize-handle {
   position: absolute;
-  background-color: #3b82f6;
+  background-color: #FFD700;
   border: 1px solid white;
   width: 8px;
   height: 8px;

--- a/client/src/app/components/raceday/default-raceday.component.css
+++ b/client/src/app/components/raceday/default-raceday.component.css
@@ -270,18 +270,18 @@ app-default-raceday {
   .layout-customizer-toolbox {
     position: relative;
     width: 260px;
-    background-color: rgba(10, 15, 30, 0.85);
+    background-color: rgba(255, 215, 0, 0.9);
     backdrop-filter: blur(16px);
-    border: 1px solid rgba(56, 189, 248, 0.45);
-    border-top: 4px solid #38bdf8;
+    border: 2px solid #FFD700;
+    border-top: 4px solid #FFD700;
     border-radius: 8px;
-    box-shadow: 0 0 20px rgba(56, 189, 248, 0.25), 0 10px 30px rgba(0, 0, 0, 0.7), inset 0 0 15px rgba(56, 189, 248, 0.05);
+    box-shadow: 0 0 20px rgba(255, 215, 0, 0.5), 0 10px 30px rgba(0, 0, 0, 0.7), inset 0 0 15px rgba(255, 215, 0, 0.2);
     display: flex;
     flex-direction: column;
     max-height: 40vh;
     overflow: hidden;
     font-family: 'Rajdhani', sans-serif;
-    color: #e2e8f0;
+    color: #000;
     box-sizing: border-box;
   }
 
@@ -292,10 +292,10 @@ app-default-raceday {
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 1px;
-    color: #38bdf8;
-    text-shadow: 0 0 10px rgba(56, 189, 248, 0.5);
-    background-color: rgba(15, 23, 42, 0.6);
-    border-bottom: 1px solid rgba(56, 189, 248, 0.2);
+    color: #000;
+    text-shadow: none;
+    background-color: rgba(255, 215, 0, 0.9);
+    border-bottom: 1px solid rgba(255, 215, 0, 0.3);
     display: flex;
     align-items: center;
     user-select: none;
@@ -304,8 +304,8 @@ app-default-raceday {
   .toolbox-subtitle {
     padding: 10px 16px;
     font-size: 13px;
-    color: #94a3b8;
-    border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+    color: #000;
+    border-bottom: 1px solid rgba(255, 215, 0, 0.2);
     line-height: 1.4;
   }
 
@@ -323,11 +323,11 @@ app-default-raceday {
     align-items: center;
     gap: 8px;
     padding: 8px 12px;
-    background-color: rgba(56, 189, 248, 0.05);
-    border: 1px solid rgba(56, 189, 248, 0.15);
+    background-color: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(0, 0, 0, 0.2);
     border-radius: 6px;
     cursor: grab;
-    color: #e2e8f0;
+    color: #000;
     font-size: 13.5px;
     font-weight: 600;
     text-transform: uppercase;
@@ -336,20 +336,20 @@ app-default-raceday {
   }
 
   .toolbox-widget-item:hover {
-    background-color: rgba(56, 189, 248, 0.15);
-    border-color: #38bdf8;
-    color: #ffffff;
-    box-shadow: 0 0 10px rgba(56, 189, 248, 0.2);
+    background-color: rgba(255, 255, 255, 1);
+    border-color: #000;
+    color: #000;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
   }
 
   .toolbox-widget-icon {
     font-size: 17px;
-    color: #38bdf8;
+    color: #000;
   }
 
   .drag-indicator-icon {
     font-size: 17px;
-    color: rgba(56, 189, 248, 0.4);
+    color: #000;
     cursor: grab;
     user-select: none;
   }
@@ -366,7 +366,7 @@ app-default-raceday {
 
   .toolbox-empty-msg {
     font-size: 12px;
-    color: #64748b;
+    color: #000;
     text-align: center;
     padding: 24px 0;
     font-style: italic;
@@ -377,7 +377,7 @@ app-default-raceday {
     flex-direction: column;
     gap: 8px;
     padding: 10px 16px 16px 16px;
-    border-top: 1px solid rgba(148, 163, 184, 0.1);
+    border-top: 1px solid rgba(255, 215, 0, 0.2);
     background-color: rgba(15, 23, 42, 0.3);
   }
 
@@ -398,31 +398,31 @@ app-default-raceday {
   }
 
   .save-btn {
-    background: #3b82f6;
-    color: #fff;
+    background: rgba(255, 215, 0, 0.8);
+    color: #000;
   }
 
   .save-btn:hover {
-    background: #2563eb;
+    background: rgba(255, 215, 0, 1);
   }
 
   .cancel-btn {
-    background: rgba(71, 85, 105, 0.6);
-    color: #e2e8f0;
+    background: rgba(255, 215, 0, 0.5);
+    color: #000;
   }
 
   .cancel-btn:hover {
-    background: rgba(71, 85, 105, 0.8);
+    background: rgba(255, 215, 0, 0.7);
   }
 
   .reset-btn {
-    background: transparent;
+    background: rgba(239, 68, 68, 0.2);
     color: #ef4444;
-    border: 1px solid rgba(239, 68, 68, 0.4);
+    border: 1px solid rgba(239, 68, 68, 0.5);
   }
 
   .reset-btn:hover {
-    background: rgba(239, 68, 68, 0.1);
+    background: rgba(239, 68, 68, 0.3);
     border-color: #ef4444;
   }
 }

--- a/client/src/app/components/raceday/default-raceday.component.html
+++ b/client/src/app/components/raceday/default-raceday.component.html
@@ -157,7 +157,7 @@
             style="
               background: none;
               border: none;
-              color: #38bdf8;
+              color: #000;
               cursor: pointer;
               display: flex;
               align-items: center;

--- a/client/src/app/components/raceday/default-raceday.component.ts
+++ b/client/src/app/components/raceday/default-raceday.component.ts
@@ -559,7 +559,10 @@ export class DefaultRacedayComponent
       const settings = this.editingSettings();
       if (settings) {
         this.isLayoutEditorMinimized = settings.layoutEditorMinimized ?? false;
-        this.layoutEditorPosition = { x: 0, y: 0 };
+        this.layoutEditorPosition = {
+          x: settings.layoutEditorPositionX ?? 0,
+          y: settings.layoutEditorPositionY ?? 0,
+        };
         if (settings.racedayLayout?.widgets) {
           this.layout = JSON.parse(JSON.stringify(settings.racedayLayout));
         } else {
@@ -612,7 +615,10 @@ export class DefaultRacedayComponent
     const settings =
       this.editingSettings() || this.settingsService.getSettings();
     this.isLayoutEditorMinimized = settings.layoutEditorMinimized ?? false;
-    this.layoutEditorPosition = { x: 0, y: 0 };
+    this.layoutEditorPosition = {
+      x: settings.layoutEditorPositionX ?? 0,
+      y: settings.layoutEditorPositionY ?? 0,
+    };
     if (settings.racedayLayout && settings.racedayLayout.widgets) {
       this.layout = JSON.parse(JSON.stringify(settings.racedayLayout));
     } else {

--- a/client/src/app/components/raceday/default-raceday.component.ts
+++ b/client/src/app/components/raceday/default-raceday.component.ts
@@ -559,10 +559,7 @@ export class DefaultRacedayComponent
       const settings = this.editingSettings();
       if (settings) {
         this.isLayoutEditorMinimized = settings.layoutEditorMinimized ?? false;
-        this.layoutEditorPosition = {
-          x: settings.layoutEditorPositionX ?? 0,
-          y: settings.layoutEditorPositionY ?? 0,
-        };
+        this.layoutEditorPosition = { x: 0, y: 0 };
         if (settings.racedayLayout?.widgets) {
           this.layout = JSON.parse(JSON.stringify(settings.racedayLayout));
         } else {
@@ -615,10 +612,7 @@ export class DefaultRacedayComponent
     const settings =
       this.editingSettings() || this.settingsService.getSettings();
     this.isLayoutEditorMinimized = settings.layoutEditorMinimized ?? false;
-    this.layoutEditorPosition = {
-      x: settings.layoutEditorPositionX ?? 0,
-      y: settings.layoutEditorPositionY ?? 0,
-    };
+    this.layoutEditorPosition = { x: 0, y: 0 };
     if (settings.racedayLayout && settings.racedayLayout.widgets) {
       this.layout = JSON.parse(JSON.stringify(settings.racedayLayout));
     } else {

--- a/client/src/app/components/ui-editor/column-toolbox/column-toolbox.component.css
+++ b/client/src/app/components/ui-editor/column-toolbox/column-toolbox.component.css
@@ -3,19 +3,19 @@
   right: 12px;
   top: 12px;
   width: 260px;
-  background-color: rgba(10, 15, 30, 0.85);
+  background-color: rgba(255, 215, 0, 0.9);
   backdrop-filter: blur(16px);
-  border: 1px solid rgba(56, 189, 248, 0.45);
-  border-top: 4px solid #38bdf8;
+  border: 2px solid #FFD700;
+  border-top: 4px solid #FFD700;
   border-radius: 8px;
-  box-shadow: 0 0 20px rgba(56, 189, 248, 0.25), 0 10px 30px rgba(0, 0, 0, 0.7), inset 0 0 15px rgba(56, 189, 248, 0.05);
+  box-shadow: 0 0 20px rgba(255, 215, 0, 0.5), 0 10px 30px rgba(0, 0, 0, 0.7), inset 0 0 15px rgba(255, 215, 0, 0.2);
   display: flex;
   flex-direction: column;
   z-index: 10000;
   max-height: 40vh;
   overflow: hidden;
   font-family: 'Rajdhani', sans-serif;
-  color: #e2e8f0;
+  color: #000;
 }
 
 .toolbox-title {
@@ -24,10 +24,10 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: #38bdf8;
-  text-shadow: 0 0 10px rgba(56, 189, 248, 0.5);
-  background-color: rgba(15, 23, 42, 0.6);
-  border-bottom: 1px solid rgba(56, 189, 248, 0.2);
+  color: #000;
+  text-shadow: none;
+  background-color: rgba(255, 215, 0, 0.9);
+  border-bottom: 2px solid #FFD700;
   display: flex;
   align-items: center;
   user-select: none;
@@ -36,7 +36,7 @@
 .toolbox-subtitle {
   padding: 10px 16px;
   font-size: 13px;
-  color: #94a3b8;
+  color: #000;
   border-bottom: 1px solid rgba(148, 163, 184, 0.1);
   line-height: 1.4;
 }
@@ -61,7 +61,7 @@
 }
 
 .toolbox-widget-list::-webkit-scrollbar-thumb {
-  background: rgba(56, 189, 248, 0.4);
+  background: rgba(0, 0, 0, 0.4);
   border-radius: 3px;
   border: 1px solid rgba(15, 23, 42, 0.2);
 }
@@ -71,11 +71,11 @@
   align-items: center;
   gap: 8px;
   padding: 8px 12px;
-  background-color: rgba(56, 189, 248, 0.05);
-  border: 1px solid rgba(56, 189, 248, 0.15);
+  background-color: rgba(255, 255, 255, 0.9);
+  border: 2px solid #FFD700;
   border-radius: 6px;
   cursor: grab;
-  color: #e2e8f0;
+  color: #000;
   font-size: 13.5px;
   font-weight: 600;
   text-transform: uppercase;
@@ -84,10 +84,10 @@
 }
 
 .toolbox-widget-item:hover {
-  background-color: rgba(56, 189, 248, 0.15);
-  border-color: #38bdf8;
-  color: #ffffff;
-  box-shadow: 0 0 10px rgba(56, 189, 248, 0.2);
+  background-color: #FFF59D;
+  border-color: #FFD700;
+  color: #000;
+  box-shadow: 0 0 10px rgba(255, 215, 0, 0.4);
 }
 
 .toolbox-widget-item:active {
@@ -96,12 +96,12 @@
 
 .drag-indicator-icon {
   font-size: 17px;
-  color: rgba(56, 189, 248, 0.4);
+  color: rgba(0, 0, 0, 0.5);
 }
 
 .toolbox-widget-icon {
   font-size: 17px;
-  color: #38bdf8;
+  color: #000;
 }
 
 .toolbox-widget-label {

--- a/client/src/app/components/ui-editor/column-toolbox/column-toolbox.component.html
+++ b/client/src/app/components/ui-editor/column-toolbox/column-toolbox.component.html
@@ -31,7 +31,7 @@
       style="
         background: none;
         border: none;
-        color: #38bdf8;
+        color: #000;
         cursor: pointer;
         display: flex;
         align-items: center;

--- a/client/src/app/components/ui-editor/ui-editor.component.css
+++ b/client/src/app/components/ui-editor/ui-editor.component.css
@@ -315,14 +315,16 @@
 }
 
 .btn-danger {
-  background: linear-gradient(to right, #e74c3c, #c0392b);
-  color: #fff;
-  box-shadow: 0 4px 10px rgba(231, 76, 60, 0.3);
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.5);
+  color: #ef4444;
+  box-shadow: 0 0 10px rgba(239, 68, 68, 0.1);
 }
 
 .btn-danger:hover:not(:disabled) {
-  filter: brightness(1.2);
-  box-shadow: 0 0 15px rgba(231, 76, 60, 0.5);
+  background: rgba(239, 68, 68, 0.2);
+  border-color: #ef4444;
+  box-shadow: 0 0 15px rgba(239, 68, 68, 0.3);
 }
 
 .btn-save {
@@ -513,7 +515,7 @@
   right: 15px;
   top: 50%;
   transform: translateY(-50%);
-  color: #38bdf8;
+  color: #000;
   pointer-events: none;
   font-size: 20px;
 }
@@ -713,19 +715,17 @@
 
 .widget-inspector-panel {
   width: 220px;
-  background: rgba(15, 23, 42, 0.95);
-  border: 1px solid rgba(56, 189, 248, 0.35);
+  background: rgba(255, 215, 0, 0.9);
+  border: 2px solid #FFD700;
   border-radius: 8px;
   padding: 15px;
   box-sizing: border-box;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4), inset 0 0 10px rgba(56, 189, 248, 0.05);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 4px 20px rgba(255, 215, 0, 0.5), 0 10px 30px rgba(0, 0, 0, 0.7), inset 0 0 15px rgba(255, 215, 0, 0.2);
   animation: slide-in 0.25s cubic-bezier(0.16, 1, 0.3, 1);
-  height: 608px;
-  max-height: 100%;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  transform: translateZ(0);
+  max-height: 608px;
+  overflow-y: auto;
+  color: #000;
 }
 
 
@@ -746,13 +746,13 @@
   width: 6px;
 }
 
-.inspector-body::-webkit-scrollbar-track {
-  background: rgba(15, 23, 42, 0.4);
+.widget-inspector-panel::-webkit-scrollbar-track {
+  background: rgba(255, 215, 0, 0.3);
   border-radius: 3px;
 }
 
-.inspector-body::-webkit-scrollbar-thumb {
-  background: rgba(56, 189, 248, 0.4);
+.widget-inspector-panel::-webkit-scrollbar-thumb {
+  background: rgba(255, 215, 0, 0.6);
   border-radius: 3px;
   border: 1px solid rgba(15, 23, 42, 0.2);
 }
@@ -772,7 +772,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  border-bottom: 2px solid #FFD700;
   padding-bottom: 8px;
   margin-bottom: 12px;
   flex: 0 0 30px;
@@ -783,7 +783,7 @@
 .inspector-header h2 {
   font-size: 1.1rem;
   font-weight: 600;
-  color: #38bdf8;
+  color: #000;
   margin: 0;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -792,7 +792,7 @@
 .inspector-close-btn {
   background: transparent;
   border: none;
-  color: #94a3b8;
+  color: #000;
   font-size: 20px;
   cursor: pointer;
   line-height: 1;
@@ -815,7 +815,7 @@
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
-  color: #94a3b8;
+  color: #000;
   letter-spacing: 0.5px;
 }
 
@@ -826,19 +826,19 @@
 }
 
 .inspector-val-badge {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: bold;
-  color: #38bdf8;
-  background: rgba(56, 189, 248, 0.15);
+  color: #000;
+  background: #fff;
   padding: 1px 6px;
   border-radius: 4px;
 }
 
 .inspector-value-readonly {
   font-size: 13px;
-  color: #f8fafc;
-  background: rgba(15, 23, 42, 0.4);
-  border: 1px solid rgba(148, 163, 184, 0.15);
+  color: #000;
+  background: rgba(255, 255, 255, 0.8);
+  border: 2px solid #FFD700;
   border-radius: 4px;
   padding: 6px 10px;
   font-family: 'SFMono-Regular', Consolas, monospace;
@@ -866,15 +866,15 @@
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: #38bdf8;
+  background: #000;
   cursor: pointer;
-  box-shadow: 0 0 8px rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.6);
   transition: transform 0.1s, background-color 0.1s;
 }
 
 .inspector-slider::-webkit-slider-thumb:hover {
   transform: scale(1.2);
-  background: #0ea5e9;
+  background: #000;
 }
 
 .inspector-slider:disabled {
@@ -915,8 +915,8 @@
 }
 
 .color-picker-placeholder {
-  font-size: 10px;
-  color: #64748b;
+  font-size: 9px;
+  color: #fff;
   font-style: italic;
   pointer-events: none;
   text-transform: uppercase;
@@ -925,6 +925,7 @@
 }
 
 .color-picker-input {
+  appearance: none;
   -webkit-appearance: none;
   border: none;
   width: 32px;
@@ -947,7 +948,7 @@
 .color-reset-btn {
   background: transparent;
   border: none;
-  color: #64748b;
+  color: #fff;
   font-size: 11px;
   cursor: pointer;
   padding: 2px;

--- a/client/src/app/components/ui-editor/ui-editor.component.html
+++ b/client/src/app/components/ui-editor/ui-editor.component.html
@@ -133,8 +133,14 @@
                   </div>
 
                   <button
-                    class="btn btn-secondary"
+                    class="btn btn-danger"
                     (click)="resetRacedayLayout()"
+                    style="
+                      display: flex;
+                      align-items: center;
+                      justify-content: center;
+                      gap: 8px;
+                    "
                   >
                     <span class="material-icons">refresh</span>
                     Reset Layout to Defaults


### PR DESCRIPTION
All color updates are for better visibility in a sea of blue.
No functional changes.

 This commit introduces a gold/yellow color scheme throughout the UI editor:

- Widget inspector panel: Changed to gold/yellow theme (#FFD700) with semi-transparent background and matching borders
- Yellow drag points: Updated drag handle styling to use the gold/yellow color scheme for better visibility
- Scrollbar styling: Applied gold/yellow colors to scrollbar tracks and thumbs in the inspector panel
- Color picker placeholder: Adjusted font styling to match the new color scheme
- Reset Layout to Defaults button: Applied red color and adjusted icon alignment

<img width="1575" height="874" alt="image" src="https://github.com/user-attachments/assets/e788a88f-0256-42bc-912e-811038f48304" />


<img width="381" height="176" alt="image" src="https://github.com/user-attachments/assets/d53b6205-44ba-4f9b-b5ae-8fd37dae2c03" />

