### PR TITLE
Change timer default font from Courier New to Tahoma

### DIFF
--- a/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.css
+++ b/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.css
@@ -22,7 +22,7 @@
 }
 
 .timer-text {
-  font-family: 'Courier New', Courier, monospace;
+  font-family: 'Tahoma', sans-serif;
   font-size: 100px;
   /* Scaled down slightly to fit labels */
   font-weight: bold;


### PR DESCRIPTION
In order to cut down on all the different fonts used by default, change timer font from Courier New to Tahoma


<img width="388" height="211" alt="image" src="https://github.com/user-attachments/assets/a2884eba-c642-4760-b8a4-ab6d8f021f56" />
