### PR TITLE
Fix timer vertical centering and label layout constraints

### DIFF
--- a/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.css
+++ b/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.css
@@ -19,24 +19,40 @@
   align-items: center;
   justify-content: center;
   width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+.label-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 24px;
+  box-sizing: border-box;
+  position: absolute;
+}
+
+.top-label {
+  top: 0;
+}
+
+.bottom-label {
+  bottom: 0;
 }
 
 .timer-text {
   font-family: 'Tahoma', sans-serif;
   font-size: 100px;
-  /* Scaled down slightly to fit labels */
   font-weight: bold;
   color: #32cd32;
-  /* LimeGreen */
   text-shadow: 0 0 24px rgba(50, 205, 50, 0.5);
   line-height: 1;
-}
-
-.timer-status-labels {
+  flex: 1;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  margin-top: 4px;
+  justify-content: center;
+  transform: translateY(-7px);
 }
 
 .status-label {
@@ -44,10 +60,10 @@
   font-size: 16px;
   font-weight: 700;
   color: #ffaa00;
-  /* Gold */
   text-transform: uppercase;
   letter-spacing: 2px;
   text-shadow: 0 0 8px rgba(255, 170, 0, 0.5);
+  white-space: nowrap;
 }
 
 .warmup-label {
@@ -55,24 +71,22 @@
   font-size: 20px;
   font-weight: 800;
   color: #00ffff;
-  /* Neon Cyan */
   text-transform: uppercase;
   letter-spacing: 3px;
   text-shadow: 0 0 12px rgba(0, 255, 255, 0.6);
-  margin-top: 2px;
+  white-space: nowrap;
   animation: pulse-glow 1.5s infinite ease-in-out;
 }
 
 @keyframes pulse-glow {
-
   0%,
   100% {
     opacity: 0.7;
     transform: scale(1);
   }
-
   50% {
     opacity: 1;
     transform: scale(1.02);
   }
 }
+

--- a/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.html
+++ b/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.html
@@ -1,5 +1,15 @@
 <div #timerPanel class="panel-card timer-panel">
   <div class="timer-wrapper">
+    <!-- Top area for auto-advance label (always rendered to reserve space) -->
+    <div class="label-container top-label">
+      @if (autoStatusLabel() && !showCountdownOverlay()) {
+        <div class="status-label">
+          {{ autoStatusLabel() | translate }}
+        </div>
+      }
+    </div>
+
+    <!-- Clock: fixed height, always centered exactly -->
     <div
       #timerText
       class="timer-text"
@@ -13,12 +23,9 @@
     >
       {{ formattedTime() }}
     </div>
-    <div class="timer-status-labels">
-      @if (autoStatusLabel() && !showCountdownOverlay()) {
-        <div class="status-label">
-          {{ autoStatusLabel() | translate }}
-        </div>
-      }
+
+    <!-- Bottom area for warmup label (always rendered to reserve space) -->
+    <div class="label-container bottom-label">
       @if (isWarmup()) {
         <div class="warmup-label">
           {{ "RD_WARMUP" | translate }}


### PR DESCRIPTION
Timer labels: status above timer, warmup below

Timer always vertically centered - not moving up and down when auto-advance/start and warmup text show up

It's already prepared to also fit with the Tahoma font from https://github.com/daufderheide/racecoordinator_ai/pull/419

<img width="357" height="203" alt="image" src="https://github.com/user-attachments/assets/4d5c23cc-2f35-4c29-b481-fc0b5a0d2683" />



