### PR TITLE
test: fix snapshot path truncation when using Windows short paths

### DIFF
--- a/run_client_screendiff_tests.ps1
+++ b/run_client_screendiff_tests.ps1
@@ -94,9 +94,10 @@ $TestExitCode = $LASTEXITCODE
 # If updating snapshots, copy them back to the original source directory
 if ($args -contains "--update-snapshots") {
     Write-Host "Syncing updated snapshots back to source..." -ForegroundColor Cyan
-    $SnapshotDirs = Get-ChildItem -Path (Join-Path $IsolatedDir "src") -Filter "*-snapshots" -Recurse -Directory
+    $FullIsolatedDir = (Get-Item $IsolatedDir).FullName
+    $SnapshotDirs = Get-ChildItem -Path (Join-Path $FullIsolatedDir "src") -Filter "*-snapshots" -Recurse -Directory
     foreach ($dir in $SnapshotDirs) {
-        $relativePath = $dir.FullName.Substring($IsolatedDir.Length + 1)
+        $relativePath = $dir.FullName.Substring($FullIsolatedDir.Length + 1)
         $destPath = Join-Path $ClientDir $relativePath
         if (-not (Test-Path $destPath)) {
             New-Item -ItemType Directory -Path $destPath -Force | Out-Null


### PR DESCRIPTION
Fix snapshot copy path truncation when running on Windows with short usernames (8.3 format).

$env:TEMP returns a short path (e.g. CRXE~1) but Get-ChildItem returns full paths, causing Substring() to strip off the wrong number of characters and write snapshots to a corrupted directory. Resolved by normalising $IsolatedDir via (Get-Item $IsolatedDir).FullName before using its length.
