### PR TITLE
Hide countdown timer during start lights for Lap based races too

### DIFF
--- a/client/src/app/components/raceday/default-raceday.component.spec.ts
+++ b/client/src/app/components/raceday/default-raceday.component.spec.ts
@@ -2725,6 +2725,56 @@ describe("DefaultRacedayComponent", () => {
       tick();
       expect(component["showCountdownOverlay"]).toBeFalse();
     }));
+
+    it("should not show autoStartRemaining on timer during STARTING state", fakeAsync(() => {
+      component["race"] = {
+        ...MOCK_RACES[0],
+        start_time: 5.0,
+        heat_scoring: { finishMethod: FinishMethod.Timed },
+      } as any;
+      raceStateSubject.next(RaceState.STARTING);
+      tick();
+
+      // During STARTING, timer should show actual race time (0), not autoStartRemaining
+      raceTimeSubject.next({ time: 0, autoStartRemaining: 5.0 });
+      tick();
+
+      expect(component["time"]).toBe(0);
+      expect(component["showCountdownOverlay"]).toBeTrue();
+    }));
+
+    it("should not show autoStartRemaining on timer during STARTING state for Lap races", fakeAsync(() => {
+      component["race"] = {
+        ...MOCK_RACES[0],
+        start_time: 5.0,
+        heat_scoring: { finishMethod: FinishMethod.Lap },
+      } as any;
+      raceStateSubject.next(RaceState.STARTING);
+      tick();
+
+      // During STARTING, timer should show actual race time (0), not autoStartRemaining
+      raceTimeSubject.next({ time: 0, autoStartRemaining: 5.0 });
+      tick();
+
+      expect(component["time"]).toBe(0);
+      expect(component["showCountdownOverlay"]).toBeTrue();
+    }));
+
+    it("should show autoStartRemaining on timer when NOT in STARTING state", fakeAsync(() => {
+      component["race"] = {
+        ...MOCK_RACES[0],
+        start_time: 5.0,
+        heat_scoring: { finishMethod: FinishMethod.Timed },
+      } as any;
+      raceStateSubject.next(RaceState.NOT_STARTED);
+      tick();
+
+      // When NOT in STARTING, timer should show autoStartRemaining
+      raceTimeSubject.next({ time: 0, autoStartRemaining: 5.0 });
+      tick();
+
+      expect(component["time"]).toBe(5.0);
+    }));
   });
 
   describe("Theme Asset Integration", () => {

--- a/client/src/app/components/raceday/default-raceday.component.ts
+++ b/client/src/app/components/raceday/default-raceday.component.ts
@@ -928,7 +928,11 @@ export class DefaultRacedayComponent
 
         const actualRaceTime = raceTime.time || 0;
         let time = actualRaceTime;
-        if (this.autoStartRemaining > 0 && !this.isRestarting) {
+        if (
+          this.raceState !== RaceState.STARTING &&
+          this.autoStartRemaining > 0 &&
+          !this.isRestarting
+        ) {
           time = this.autoStartRemaining;
         } else if (this.autoAdvanceRemaining > 0) {
           time = this.autoAdvanceRemaining;
@@ -942,10 +946,7 @@ export class DefaultRacedayComponent
         if (time > this.previousTime) {
           this.timeFormat = "1.0-0";
         } else if (time < this.previousTime) {
-          if (
-            this.raceState === RaceState.STARTING &&
-            this.race?.heat_scoring?.finishMethod === FinishMethod.Timed
-          ) {
+          if (this.raceState === RaceState.STARTING) {
             this.timeFormat = "1.0-0";
           } else {
             const timerWidget = this.layout?.widgets?.find(


### PR DESCRIPTION
- Prevents countdown timer from being displayed on timer during STARTING state
- Start lights overlay remains visible
- Applies to both Timed and Lap-based races

Continuation of https://github.com/daufderheide/racecoordinator_ai/pull/449, which focused solely on Timed based races