### PR TITLE
fix: add MAVEN_OPTS for protoc maven compile

### DIFF
--- a/server/generate_protos.ps1
+++ b/server/generate_protos.ps1
@@ -46,6 +46,7 @@ if (Test-Path $LOCAL_PROTOC) {
         Write-Host "Attempting to download via 'mvn protobuf:compile'..."
         # Run maven to download protoc
         Set-Location $SERVER_DIR
+        $env:MAVEN_OPTS = '--add-opens java.base/java.lang=ALL-UNNAMED'
         mvn protobuf:compile 2>&1 | Out-Null
     }
 


### PR DESCRIPTION
Agent:
The PowerShell script generate_protos.ps1 has been updated to suppress the “restricted method in java.lang.System has been called” warning that appears when Maven runs the protobuf compilation.

What was changed

```
diff
-        mvn protobuf:compile 2>&1 | Out-Null
+        $env:MAVEN_OPTS = '--add-opens java.base/java.lang=ALL-UNNAMED'
+        mvn protobuf:compile 2>&1 | Out-Null
```

Added the MAVEN_OPTS environment variable just before the Maven command.
The option --add-opens java.base/java.lang=ALL-UNNAMED tells the JVM to allow the reflective access that Maven (and the protobuf plugin) attempts, preventing the warning from being emitted.

Why this works
MAVEN_OPTS is read by the Maven launcher and passed to the Java process that runs the build. By opening the java.lang package to all modules, the JVM no longer treats the reflective call as a security restriction, eliminating the warning.