### PR TITLE
fix: improve timer text scaling and centering

### DIFF
--- a/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.css
+++ b/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.css
@@ -43,7 +43,7 @@
 
 .timer-text {
   font-family: 'Tahoma', sans-serif;
-  font-size: 100px;
+  font-size: var(--timer-font-size, 100px);
   font-weight: bold;
   color: #32cd32;
   text-shadow: 0 0 24px rgba(50, 205, 50, 0.5);
@@ -52,7 +52,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transform: translateY(-7px);
+  overflow: hidden;
+  min-height: 0;
+  width: 100%;
+  text-align: center;
+  padding: 0 4px;
+  transform: translateY(var(--timer-text-offset, -7px));
 }
 
 .status-label {

--- a/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.ts
+++ b/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.ts
@@ -90,9 +90,12 @@ export class RacedayTimerComponent implements AfterViewInit, OnDestroy {
     // Height of text at 100px font-size is roughly 100px (line-height is 1)
     const textHeight = 100;
 
-    // Pad container bounds (12% horizontal margin, 24% vertical margin to accommodate labels)
+    // Always reserve space for both labels so timer size stays consistent
+    const reservedLabelHeight = 48;
+
+    // Pad container bounds (12% horizontal margin, reserve label height vertically)
     const containerWidth = panelEl.clientWidth * 0.88;
-    const containerHeight = panelEl.clientHeight * 0.76;
+    const containerHeight = Math.max(1, panelEl.clientHeight - reservedLabelHeight);
 
     const scaleX = containerWidth / textWidth;
     const scaleY = containerHeight / textHeight;
@@ -101,7 +104,11 @@ export class RacedayTimerComponent implements AfterViewInit, OnDestroy {
     const baseScaleFactor = widgetData?.textScaleFactor ?? 1;
     const targetFontSize = Math.floor(100 * scale * baseScaleFactor);
 
+    // Proportional vertical offset so text stays visually centered at any size
+    const textOffset = Math.max(0, Math.floor(targetFontSize * 0.05));
+
     // Apply via CSS custom property so children scale too
     panelEl.style.setProperty("--timer-font-size", `${targetFontSize}px`);
+    panelEl.style.setProperty("--timer-text-offset", `-${textOffset}px`);
   }
 }


### PR DESCRIPTION
Fixes this, the default Practice layout

<img width="405" height="107" alt="image" src="https://github.com/user-attachments/assets/55604f2b-08d5-4983-8133-2d632ba0b9c9" />

Now looks like this

<img width="397" height="110" alt="image" src="https://github.com/user-attachments/assets/2695235f-f641-45ef-8591-9040be75bcb1" />

Default Layout is visually unaffected.