### PR TITLE
Dynamic timer colors

### DIFF
--- a/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.css
+++ b/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.css
@@ -60,6 +60,16 @@
   transform: translateY(var(--timer-text-offset, -7px));
 }
 
+.timer-text.timer-warmup {
+  color: #00ffff;
+  text-shadow: 0 0 24px rgba(0, 255, 255, 0.6);
+}
+
+.timer-text.timer-auto {
+  color: #ffaa00;
+  text-shadow: 0 0 24px rgba(255, 170, 0, 0.5);
+}
+
 .status-label {
   font-family: 'Orbitron', sans-serif;
   font-size: 16px;

--- a/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.html
+++ b/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.html
@@ -13,6 +13,10 @@
     <div
       #timerText
       class="timer-text"
+      [class.timer-warmup]="isWarmup()"
+      [class.timer-auto]="
+        autoStatusLabel() && !showCountdownOverlay() && !isWarmup()
+      "
       [style.font-family]="widget()?.customSettings?.['timeFontFamily'] || null"
       [style.font-size.px]="
         widget()?.scaleMode === 'fixed' || !widget()?.scaleMode

--- a/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.spec.ts
+++ b/client/src/app/components/raceday/components/raceday-timer/raceday-timer.component.spec.ts
@@ -108,4 +108,45 @@ describe("RacedayTimerComponent", () => {
     expect(timerText).toBeTruthy();
     expect(timerText.textContent.trim()).toBe("01:23");
   });
+
+  it("should apply timer-warmup class during warmup state", () => {
+    fixture.componentRef.setInput("formattedTime", "01:23");
+    fixture.componentRef.setInput("isWarmup", true);
+    fixture.detectChanges();
+    const timerText = fixture.nativeElement.querySelector(".timer-text");
+    expect(timerText.classList.contains("timer-warmup")).toBe(true);
+    expect(timerText.classList.contains("timer-auto")).toBe(false);
+  });
+
+  it("should apply timer-auto class during auto-start/auto-advance (not warmup)", () => {
+    fixture.componentRef.setInput("formattedTime", "01:23");
+    fixture.componentRef.setInput("autoStatusLabel", "RD_AUTO_START");
+    fixture.componentRef.setInput("isWarmup", false);
+    fixture.componentRef.setInput("showCountdownOverlay", false);
+    fixture.detectChanges();
+    const timerText = fixture.nativeElement.querySelector(".timer-text");
+    expect(timerText.classList.contains("timer-auto")).toBe(true);
+    expect(timerText.classList.contains("timer-warmup")).toBe(false);
+  });
+
+  it("should not apply timer-auto class during countdown overlay", () => {
+    fixture.componentRef.setInput("formattedTime", "01:23");
+    fixture.componentRef.setInput("autoStatusLabel", "RD_AUTO_START");
+    fixture.componentRef.setInput("isWarmup", false);
+    fixture.componentRef.setInput("showCountdownOverlay", true);
+    fixture.detectChanges();
+    const timerText = fixture.nativeElement.querySelector(".timer-text");
+    expect(timerText.classList.contains("timer-auto")).toBe(false);
+  });
+
+  it("should not apply timer-auto class during warmup even with auto status", () => {
+    fixture.componentRef.setInput("formattedTime", "01:23");
+    fixture.componentRef.setInput("autoStatusLabel", "RD_AUTO_START");
+    fixture.componentRef.setInput("isWarmup", true);
+    fixture.componentRef.setInput("showCountdownOverlay", false);
+    fixture.detectChanges();
+    const timerText = fixture.nativeElement.querySelector(".timer-text");
+    expect(timerText.classList.contains("timer-warmup")).toBe(true);
+    expect(timerText.classList.contains("timer-auto")).toBe(false);
+  });
 });


### PR DESCRIPTION
Add dynamic timer colors: blue for warmup, orange for auto-start/auto-advance

- Timer shows cyan (#00ffff) during warmup state (matching warmup label)
- Timer shows orange (#ffaa00) during auto-start or auto-advance states
- Default green color for normal racing state
- Only color changes, no timer logic modifications