### PR TITLE
Fix gap position wrapping in lane view grid anchors

### DIFF
--- a/client/src/app/components/raceday/components/raceday-lane-view/raceday-lane-view.component.html
+++ b/client/src/app/components/raceday/components/raceday-lane-view/raceday-lane-view.component.html
@@ -514,6 +514,16 @@
                       !parent().isTeam(hd)
                     ) {
                       <span
+                        [style.white-space]="
+                          [
+                            'gapLeader',
+                            'gapPosition',
+                            'gapLeaderF1',
+                            'gapPositionF1',
+                          ].includes(entry.property)
+                            ? 'nowrap'
+                            : 'normal'
+                        "
                         [style.padding-right]="
                           parent().race?.practice &&
                           (parent().isNameProperty(entry.property) ||


### PR DESCRIPTION
Add white-space: nowrap to gap position values (gapLeader, gapPosition, gapLeaderF1, gapPositionF1) to prevent text wrapping to 2 lines when Lane-View column is scaled narrow. This matches the behavior of lap times in the 9-grid corner/edge anchors.

Fixes https://github.com/daufderheide/racecoordinator_ai/issues/502