### PR TITLE
Fix generate_protos.ps1 warning treated as error

### DIFF
--- a/server/generate_protos.ps1
+++ b/server/generate_protos.ps1
@@ -47,7 +47,9 @@ if (Test-Path $LOCAL_PROTOC) {
         # Run maven to download protoc
         Set-Location $SERVER_DIR
         $env:MAVEN_OPTS = '--add-opens java.base/java.lang=ALL-UNNAMED'
+        $ErrorActionPreference = "Continue"
         mvn protobuf:compile 2>&1 | Out-Null
+        $ErrorActionPreference = "Stop"
     }
 
     if (Test-Path $PROTOC_M2) {


### PR DESCRIPTION
- Temporarily set ErrorActionPreference to Continue for Maven command
- Prevents Java runtime warnings from causing script failure
- Fixes issue with Java 25+ where restricted method warnings appear on stderr
- Restores ErrorActionPreference to Stop after Maven command completes