### PR TITLE
Add keyboard shortcuts for resetting lanes in Practice screen

### DIFF
--- a/client/src/app/components/raceday/default-raceday.component.spec.ts
+++ b/client/src/app/components/raceday/default-raceday.component.spec.ts
@@ -896,6 +896,146 @@ describe("DefaultRacedayComponent", () => {
       expect(component.ackModalMessage).toBe("Reset All Error");
     });
 
+    describe("Reset Lane Keyboard Shortcuts", () => {
+      beforeEach(() => {
+        mockDataService.resetLaneHeatData.and.returnValue(of(true));
+        component["race"] = { practice: true } as any;
+      });
+
+      it("should reset lane 1 on Ctrl+Alt+F1 in practice mode", () => {
+        const mockEvent = new KeyboardEvent("keydown", {
+          ctrlKey: true,
+          altKey: true,
+          key: "F1",
+        });
+        spyOn(mockEvent, "preventDefault");
+
+        component["handleKeyboardEvent"](mockEvent);
+
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(mockDataService.resetLaneHeatData).toHaveBeenCalledWith(0);
+      });
+
+      it("should reset lane 2 on Ctrl+Alt+F2 in practice mode", () => {
+        const mockEvent = new KeyboardEvent("keydown", {
+          ctrlKey: true,
+          altKey: true,
+          key: "F2",
+        });
+        spyOn(mockEvent, "preventDefault");
+
+        component["handleKeyboardEvent"](mockEvent);
+
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(mockDataService.resetLaneHeatData).toHaveBeenCalledWith(1);
+      });
+
+      it("should reset lane 3 on Ctrl+Alt+F3 in practice mode", () => {
+        const mockEvent = new KeyboardEvent("keydown", {
+          ctrlKey: true,
+          altKey: true,
+          key: "F3",
+        });
+        spyOn(mockEvent, "preventDefault");
+
+        component["handleKeyboardEvent"](mockEvent);
+
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(mockDataService.resetLaneHeatData).toHaveBeenCalledWith(2);
+      });
+
+      it("should reset lane 4 on Ctrl+Alt+F4 in practice mode", () => {
+        const mockEvent = new KeyboardEvent("keydown", {
+          ctrlKey: true,
+          altKey: true,
+          key: "F4",
+        });
+        spyOn(mockEvent, "preventDefault");
+
+        component["handleKeyboardEvent"](mockEvent);
+
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(mockDataService.resetLaneHeatData).toHaveBeenCalledWith(3);
+      });
+
+      it("should reset all lanes on Ctrl+Alt+F12 in practice mode", () => {
+        const mockEvent = new KeyboardEvent("keydown", {
+          ctrlKey: true,
+          altKey: true,
+          key: "F12",
+        });
+        spyOn(mockEvent, "preventDefault");
+
+        component["handleKeyboardEvent"](mockEvent);
+
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(mockDataService.resetLaneHeatData).toHaveBeenCalledWith("all");
+      });
+
+      it("should not reset lanes on Ctrl+Alt+F1-F4 when not in practice mode", () => {
+        component["race"] = { practice: false } as any;
+        mockDataService.resetLaneHeatData.calls.reset();
+
+        const mockEvent = new KeyboardEvent("keydown", {
+          ctrlKey: true,
+          altKey: true,
+          key: "F1",
+        });
+        spyOn(mockEvent, "preventDefault");
+
+        component["handleKeyboardEvent"](mockEvent);
+
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+        expect(mockDataService.resetLaneHeatData).not.toHaveBeenCalled();
+      });
+
+      it("should not reset all lanes on Ctrl+Alt+F12 when not in practice mode", () => {
+        component["race"] = { practice: false } as any;
+        mockDataService.resetLaneHeatData.calls.reset();
+
+        const mockEvent = new KeyboardEvent("keydown", {
+          ctrlKey: true,
+          altKey: true,
+          key: "F12",
+        });
+        spyOn(mockEvent, "preventDefault");
+
+        component["handleKeyboardEvent"](mockEvent);
+
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+        expect(mockDataService.resetLaneHeatData).not.toHaveBeenCalled();
+      });
+
+      it("should work with Cmd+Alt on Mac (simulated with metaKey)", () => {
+        const mockEvent = new KeyboardEvent("keydown", {
+          metaKey: true,
+          altKey: true,
+          key: "F1",
+        });
+        spyOn(mockEvent, "preventDefault");
+
+        component["handleKeyboardEvent"](mockEvent);
+
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+        expect(mockDataService.resetLaneHeatData).toHaveBeenCalledWith(0);
+      });
+
+      it("should not trigger on F5-F11 keys", () => {
+        const mockEvent = new KeyboardEvent("keydown", {
+          ctrlKey: true,
+          altKey: true,
+          key: "F5",
+        });
+        spyOn(mockEvent, "preventDefault");
+        mockDataService.resetLaneHeatData.calls.reset();
+
+        component["handleKeyboardEvent"](mockEvent);
+
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+        expect(mockDataService.resetLaneHeatData).not.toHaveBeenCalled();
+      });
+    });
+
     it("should call updateHeatUserLaps on confirm in menu mode", () => {
       fixture.detectChanges();
       component["isMenuModeForAddLap"] = true;

--- a/client/src/app/components/raceday/default-raceday.component.ts
+++ b/client/src/app/components/raceday/default-raceday.component.ts
@@ -2944,6 +2944,23 @@ export class DefaultRacedayComponent
       event.preventDefault();
       this.onMenuSelect("DEFER_HEAT");
     }
+
+    // Ctrl+Alt+F1-F4 for Reset Lanes 1-4
+    if (isCtrlOrCmd && event.altKey && event.key.startsWith("F")) {
+      const fKey = parseInt(event.key.replace("F", ""), 10);
+      if (fKey >= 1 && fKey <= 4) {
+        event.preventDefault();
+        this.resetLane(fKey - 1, event);
+        return;
+      }
+    }
+
+    // Ctrl+Alt+F12 for Reset All Lanes
+    if (isCtrlOrCmd && event.altKey && event.key === "F12") {
+      event.preventDefault();
+      this.resetAllLanes(event);
+      return;
+    }
   }
 
   private checkWidgetShortcuts(event: KeyboardEvent): boolean {

--- a/client/src/app/components/raceday/default-raceday.component.ts
+++ b/client/src/app/components/raceday/default-raceday.component.ts
@@ -2945,18 +2945,18 @@ export class DefaultRacedayComponent
       this.onMenuSelect("DEFER_HEAT");
     }
 
-    // Ctrl+Alt+F1-F4 for Reset Lanes 1-4
+    // Ctrl+Alt+F1-F4 for Reset Lanes 1-4 (practice mode only)
     if (isCtrlOrCmd && event.altKey && event.key.startsWith("F")) {
       const fKey = parseInt(event.key.replace("F", ""), 10);
-      if (fKey >= 1 && fKey <= 4) {
+      if (fKey >= 1 && fKey <= 4 && this.race?.practice) {
         event.preventDefault();
         this.resetLane(fKey - 1, event);
         return;
       }
     }
 
-    // Ctrl+Alt+F12 for Reset All Lanes
-    if (isCtrlOrCmd && event.altKey && event.key === "F12") {
+    // Ctrl+Alt+F12 for Reset All Lanes (practice mode only)
+    if (isCtrlOrCmd && event.altKey && event.key === "F12" && this.race?.practice) {
       event.preventDefault();
       this.resetAllLanes(event);
       return;


### PR DESCRIPTION
Feature Request: https://github.com/daufderheide/racecoordinator_ai/issues/426

- Ctrl+Alt+F1: Reset Lane 1
- Ctrl+Alt+F2: Reset Lane 2
- Ctrl+Alt+F3: Reset Lane 3
- Ctrl+Alt+F4: Reset Lane 4
- Ctrl+Alt+F12: Reset All Lanes

Shortcuts work with Ctrl+Alt on Windows and Cmd+Alt on Mac. Lane indices are 0-based, so F key number is adjusted by -1.

These shortcuts do not interfere with any default browser shortcuts (Chrome, Edge).

Together with a https://www.autohotkey.com/v2/ script, it will be possible to use F1, F2, F3, F4 and F12. the shortcuts we are used to from RC1.

> #HotIf WinActive("ahk_exe chrome.exe") || WinActive("ahk_exe msedge.exe")
> 
> F1::Send("^!{F1}")
> F2::Send("^!{F2}")
> F3::Send("^!{F3}")
> F4::Send("^!{F4}")
> F12::Send("^!{F12}")
> 
> #HotIf

